### PR TITLE
Fix Windows crash during healing by adding pointer hygiene checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ coop_config.xml
 # Private engineering workspace
 /WORKLOG.md
 /Working_plan/
+/_dissection/
 /_coop-fixtures/
 /coop-*
 /CoopPrototype/RE/

--- a/CoopPrototype/Src/CMakeLists.txt
+++ b/CoopPrototype/Src/CMakeLists.txt
@@ -74,6 +74,8 @@ set(SOURCE_FILES
 	NullUi.cpp
 	NullUi.h
     CoopPlayerSidecar.cpp
+    CoopPtrHygiene.cpp
+    CoopPtrHygiene.h
     CoopSharedDropSync.cpp
     CoopSharedStorageSync.cpp
 	CoopPlayerState.cpp

--- a/CoopPrototype/Src/CoopPlayerSidecar.cpp
+++ b/CoopPrototype/Src/CoopPlayerSidecar.cpp
@@ -2,6 +2,7 @@
 #include "CoopRuntimeConfig.h"
 #include "CoopRuntimeLog.h"
 #include "CoopItemClassification.h"
+#include "CoopPtrHygiene.h"
 #include "CoopNativeFragmentPayload.h"
 #include "CoopRuntimeGuards.h"
 
@@ -2599,6 +2600,11 @@ bool ModMain::SaveLocalPlayerSidecar(const char* reason)
 
     if (player.m_helmet.m_pOxygenComponent)
     {
+        if (CoopPtrHygiene::Enabled())
+        {
+            CoopPtrHygiene::LogPtr("player_oxygen_save", player.m_helmet.m_pOxygenComponent.get());
+            CoopPtrHygiene::CheckAbove32("player_oxygen_save", player.m_helmet.m_pOxygenComponent.get());
+        }
         ArkPlayerOxygenComponent& oxygen = *player.m_helmet.m_pOxygenComponent;
         output << "oxygen=" << oxygen.m_oxygen << ' ' << oxygen.GetMaxOxygen() << ' '
             << (oxygen.m_bConsumingOxygen ? 1 : 0) << "\n";
@@ -3641,6 +3647,11 @@ bool ModMain::ApplyLocalPlayerSidecar(const PlayerSidecarState& state, const cha
     if (applyVitals && state.hasOxygen && player.m_helmet.m_pOxygenComponent)
     {
         ArkPlayerOxygenComponent* oxygen = player.m_helmet.m_pOxygenComponent.get();
+        if (CoopPtrHygiene::Enabled())
+        {
+            CoopPtrHygiene::LogPtr("player_oxygen_apply", oxygen);
+            CoopPtrHygiene::CheckAbove32("player_oxygen_apply", oxygen);
+        }
         std::string oxygenReason;
         TryGuardedVoidCall(
             "apply player sidecar oxygen",

--- a/CoopPrototype/Src/CoopPlayerState.cpp
+++ b/CoopPrototype/Src/CoopPlayerState.cpp
@@ -1,6 +1,7 @@
 #include "ModMain.h"
 #include "CoopRuntimeLog.h"
 #include "CoopRuntimeGuards.h"
+#include "CoopPtrHygiene.h"
 
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -15,6 +16,8 @@
 #include <algorithm>
 #include <cctype>
 #include <cmath>
+#include <cstddef>
+#include <cstdio>
 #include <cstdint>
 #include <cstdlib>
 #include <string>
@@ -128,7 +131,17 @@ bool IsLocalPlayerHealthComponent(const ArkPlayerHealthComponent* healthComponen
     if (!healthComponent || !ArkPlayer::GetInstancePtr())
         return false;
 
-    return healthComponent == &ArkPlayer::GetInstance().m_playerComponent.GetHealthComponent();
+    ArkPlayerHealthComponent* localComponent = &ArkPlayer::GetInstance().m_playerComponent.GetHealthComponent();
+    if (healthComponent != localComponent && CoopPtrHygiene::Enabled())
+    {
+        char line[160];
+        std::snprintf(line, sizeof(line),
+            "ptr_hygiene tag=local_player_health_mismatch got=0x%016llX expected=0x%016llX",
+            static_cast<unsigned long long>(reinterpret_cast<std::uintptr_t>(healthComponent)),
+            static_cast<unsigned long long>(reinterpret_cast<std::uintptr_t>(localComponent)));
+        CoopRuntimeLog::WriteRateLimited("local_player_health_mismatch", line, 1.0, 3);
+    }
+    return healthComponent == localComponent;
 }
 
 void NormalizeHealthFeedbackAfterRestore(ArkPlayerHealthComponent& healthComponent, float health)
@@ -791,6 +804,40 @@ void ModMain::OnArkPlayerSignalHitObserved(const HitInfo& hitInfo, uint64_t pack
         " target=" + std::to_string(resolved.targetId);
 }
 
+// CArkSignalContext is a 16-byte { int32 variant discriminant, 8-byte payload }:
+//   0 = boost::blank, 1 = HitInfo const*, 2 = SExplosionContainer*.
+// The native GetDamage*/GetHitInfo() accessors abort the entire process (SEH
+// cannot catch it) whenever the variant does not hold a HitInfo const*, so
+// inspect the payload directly instead of calling them.
+static bool TryGetSignalContextHitInfo(
+    const ArkSignalSystem::CArkSignalContext& context,
+    const HitInfo** outHitInfo,
+    int* outVariantIndex)
+{
+    const uint8_t* base = reinterpret_cast<const uint8_t*>(&context);
+    int32_t index = -1;
+    if (!CoopRuntimeGuards::TryReadRuntimeValue(
+            reinterpret_cast<const int32_t const*>(base), index))
+    {
+        return false;
+    }
+    const void* payload = nullptr;
+    if (!CoopRuntimeGuards::TryReadRuntimeValue(
+            reinterpret_cast<const void* const*>(base + 8), payload))
+    {
+        return false;
+    }
+    if (outVariantIndex)
+        *outVariantIndex = index;
+    if (index != 1 ||
+        !CoopRuntimeGuards::IsReadableRuntimePointer(payload, sizeof(HitInfo)))
+    {
+        return false;
+    }
+    *outHitInfo = static_cast<const HitInfo*>(payload);
+    return true;
+}
+
 void ModMain::OnArkSignalPackageObserved(
     EntityId targetEntityId,
     EntityId senderEntityId,
@@ -837,12 +884,9 @@ void ModMain::OnArkSignalPackageObserved(
     pending.position = playerEntity->GetWorldPos();
 
     const HitInfo* hitInfo = nullptr;
-    if (TryGuardedCall(
-        "signal package context GetHitInfo",
-        [&context]() -> const HitInfo* { return context.GetHitInfo(); },
-        hitInfo,
-        nullptr) &&
-        hitInfo)
+    int variantIndex = -1;
+    TryGetSignalContextHitInfo(context, &hitInfo, &variantIndex);
+    if (hitInfo)
     {
         if (hitInfo->shooterId != INVALID_ENTITYID && hitInfo->shooterId != 0)
             pending.instigatorId = hitInfo->shooterId;
@@ -869,52 +913,15 @@ void ModMain::OnArkSignalPackageObserved(
     }
     else
     {
-        EntityId contextInstigator = INVALID_ENTITYID;
-        EntityId contextWeapon = INVALID_ENTITYID;
-        Vec3 contextPosition = ZERO;
-        Vec3 contextDirection = ZERO;
-        if (TryGuardedCall(
-            "signal package context instigator",
-            [&context]() -> unsigned { return context.GetDamageInstigatorId(); },
-            contextInstigator,
-            nullptr) &&
-            contextInstigator != INVALID_ENTITYID &&
-            contextInstigator != 0)
-        {
-            pending.instigatorId = contextInstigator;
-        }
-        if (TryGuardedCall(
-            "signal package context weapon",
-            [&context]() -> unsigned { return context.GetDamageWeaponId(); },
-            contextWeapon,
-            nullptr) &&
-            contextWeapon != INVALID_ENTITYID &&
-            contextWeapon != 0)
-        {
-            pending.weaponId = contextWeapon;
-        }
-        if (TryGuardedCall(
-            "signal package context position",
-            [&context]() -> Vec3 { return context.GetDamagePosition(); },
-            contextPosition,
-            nullptr) &&
-            std::isfinite(contextPosition.x) &&
-            std::isfinite(contextPosition.y) &&
-            std::isfinite(contextPosition.z) &&
-            (std::abs(contextPosition.x) > 0.001f ||
-                std::abs(contextPosition.y) > 0.001f ||
-                std::abs(contextPosition.z) > 0.001f))
-        {
-            pending.position = contextPosition;
-        }
-        if (TryGuardedCall(
-            "signal package context direction",
-            [&context]() -> Vec3 { return context.GetDamageDirection(); },
-            contextDirection,
-            nullptr))
-        {
-            pending.direction = contextDirection;
-        }
+        // The context variant does not hold a HitInfo const* (blank or
+        // explosion context, e.g. healing/water/sink signal packages). The
+        // native damage getters abort the process on such contexts, so the
+        // pending fields stay at the fallback values set above and only a
+        // breadcrumb is written.
+        const std::string breadcrumb =
+            "signal_ctx_no_hit pkg=" + std::to_string(packageId) +
+            " variant=" + std::to_string(variantIndex);
+        CoopRuntimeLog::WriteRateLimited("signal_ctx_no_hit", breadcrumb, 1.0, 3);
     }
 
     if ((pending.sourceId == INVALID_ENTITYID || pending.sourceId == 0) &&
@@ -946,11 +953,22 @@ void ModMain::OnArkSignalPackageObserved(
         nullptr);
 
     EntityId instigatorEntityId = package.m_sourceId;
-    TryGuardedCall(
-        "signal package context instigator outer",
-        [&package]() -> unsigned { return package.m_context.GetDamageInstigatorId(); },
-        instigatorEntityId,
-        nullptr);
+    // The native GetDamageInstigatorId() aborts the process when the context
+    // variant does not hold a HitInfo const*, so read the payload directly.
+    {
+        const HitInfo* contextHitInfo = nullptr;
+        if (TryGetSignalContextHitInfo(package.m_context, &contextHitInfo, nullptr))
+        {
+            unsigned contextInstigator = 0;
+            if (CoopRuntimeGuards::TryReadRuntimeValue(
+                    &contextHitInfo->shooterId, contextInstigator) &&
+                contextInstigator != INVALID_ENTITYID &&
+                contextInstigator != 0)
+            {
+                instigatorEntityId = contextInstigator;
+            }
+        }
+    }
 
     OnArkSignalPackageObserved(
         targetEntityId,
@@ -1665,6 +1683,12 @@ bool ModMain::SetLocalPlayerHealthSafe(float health, const char* reason)
     try
     {
         ArkPlayer& player = ArkPlayer::GetInstance();
+        if (CoopPtrHygiene::Enabled())
+        {
+            char extra[64];
+            std::snprintf(extra, sizeof(extra), "health=%.3f", health);
+            CoopPtrHygiene::LogPtrWith("player_health_write", &player.m_playerComponent.GetHealthComponent(), extra);
+        }
         const float currentHealth = player.GetHealth();
         if (std::isfinite(currentHealth) &&
             std::isfinite(health) &&
@@ -1954,6 +1978,12 @@ void ModMain::ReviveLocalPlayer(float health, bool sendStatus)
     if (!ArkPlayer::GetInstancePtr())
         return;
 
+    if (CoopPtrHygiene::Enabled())
+    {
+        char extra[64];
+        std::snprintf(extra, sizeof(extra), "health=%.3f", health);
+        CoopPtrHygiene::LogPtrWith("player_revive", &ArkPlayer::GetInstance().m_playerComponent.GetHealthComponent(), extra);
+    }
     m_localPlayerDowned = false;
     m_teamWipe = false;
     m_localReviveSuppressDownedStatusSeconds = kPostReviveDownedGraceSeconds;

--- a/CoopPrototype/Src/CoopPtrHygiene.cpp
+++ b/CoopPrototype/Src/CoopPtrHygiene.cpp
@@ -1,0 +1,207 @@
+#include "CoopPtrHygiene.h"
+
+#include "CoopRuntimeConfig.h"
+#include "CoopRuntimeLog.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+
+namespace
+{
+constexpr const char* kEnvFlagName = "COOP_PTR_HYGIENE";
+constexpr const char* kMarkerFileName = "CoopPtrHygiene.txt";
+constexpr std::uint64_t kMarkerRecheckIntervalMs = 2000;
+
+std::atomic<bool> g_enabled{false};
+std::atomic<bool> g_explicitlySet{false};
+std::atomic<bool> g_initialized{false};
+std::atomic<std::uint64_t> g_lastMarkerCheckMs{0};
+
+bool EnvFlagValue()
+{
+    return CoopRuntimeConfig::Flag(kEnvFlagName);
+}
+
+// GetPreyProfileRoot() is intentionally duplicated per translation unit in
+// this codebase (see ModMain.cpp and CoopPlayerSidecar.cpp), so the same
+// 5-line USERPROFILE logic is duplicated here instead of reaching into
+// ModMain internals.
+std::filesystem::path GetPreyProfileRoot()
+{
+    const char* userProfile = std::getenv("USERPROFILE");
+    if (!userProfile || !userProfile[0])
+        return {};
+
+    std::filesystem::path root(userProfile);
+    root /= "Saved Games";
+    root /= "Arkane Studios";
+    root /= "Prey";
+    return root;
+}
+
+bool MarkerFilePresent()
+{
+    const std::filesystem::path root = GetPreyProfileRoot();
+    if (root.empty())
+        return false;
+
+    std::error_code error;
+    const bool exists = std::filesystem::exists(root / kMarkerFileName, error);
+    return exists && !error;
+}
+
+std::uint64_t NowMs()
+{
+    return static_cast<std::uint64_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now().time_since_epoch())
+            .count());
+}
+
+void SetEnabledInternal(bool enabled, bool explicitSet, const char* source)
+{
+    g_enabled.store(enabled, std::memory_order_release);
+    if (explicitSet)
+        g_explicitlySet.store(true, std::memory_order_release);
+    char line[128];
+    std::snprintf(line, sizeof(line), "ptr_hygiene state enabled=%d source=%s",
+        enabled ? 1 : 0,
+        source ? source : "unknown");
+    CoopRuntimeLog::Write(line);
+}
+}
+
+void CoopPtrHygiene::Initialize()
+{
+    bool expected = false;
+    if (!g_initialized.compare_exchange_strong(
+            expected, true, std::memory_order_acq_rel, std::memory_order_relaxed))
+    {
+        // Already initialized (hot reload): keep the runtime state.
+        return;
+    }
+
+    g_lastMarkerCheckMs.store(NowMs(), std::memory_order_relaxed);
+    const bool env = EnvFlagValue();
+    const bool marker = MarkerFilePresent();
+    char line[160];
+    std::snprintf(line, sizeof(line),
+        "ptr_hygiene init enabled=%d env=%d marker=%d",
+        (env || marker) ? 1 : 0,
+        env ? 1 : 0,
+        marker ? 1 : 0);
+    CoopRuntimeLog::Write(line);
+    if (env || marker)
+        g_enabled.store(true, std::memory_order_release);
+}
+
+bool CoopPtrHygiene::Enabled()
+{
+    return g_enabled.load(std::memory_order_relaxed);
+}
+
+void CoopPtrHygiene::SetEnabled(bool enabled)
+{
+    SetEnabledInternal(enabled, true, "runtime_command");
+}
+
+void CoopPtrHygiene::Tick()
+{
+    // Steady state when tracing is pinned on (explicit command or env flag):
+    // the marker cannot disable it, so only the atomic loads run.
+    if (g_enabled.load(std::memory_order_relaxed) &&
+        (g_explicitlySet.load(std::memory_order_relaxed) || EnvFlagValue()))
+    {
+        return;
+    }
+
+    const std::uint64_t now = NowMs();
+    std::uint64_t last = g_lastMarkerCheckMs.load(std::memory_order_relaxed);
+    if (now - last < kMarkerRecheckIntervalMs)
+        return;
+    if (!g_lastMarkerCheckMs.compare_exchange_weak(
+            last, now, std::memory_order_relaxed, std::memory_order_relaxed))
+        return;
+
+    const bool marker = MarkerFilePresent();
+    if (marker && !g_enabled.load(std::memory_order_relaxed))
+    {
+        SetEnabledInternal(true, false, "marker_file");
+        return;
+    }
+    if (!marker &&
+        g_enabled.load(std::memory_order_relaxed) &&
+        !g_explicitlySet.load(std::memory_order_relaxed) &&
+        !EnvFlagValue())
+    {
+        SetEnabledInternal(false, false, "marker_file_removed");
+    }
+}
+
+void CoopPtrHygiene::LogPtr(const char* tag, const void* ptr)
+{
+    LogPtrWith(tag, ptr, nullptr);
+}
+
+void CoopPtrHygiene::LogPtrWith(const char* tag, const void* ptr, const char* extraTokens)
+{
+    if (!g_enabled.load(std::memory_order_relaxed))
+        return;
+
+    const std::uintptr_t address = reinterpret_cast<std::uintptr_t>(ptr);
+    const int above32 = (address >> 32) != 0 ? 1 : 0;
+    char line[256];
+    if (extraTokens != nullptr && extraTokens[0] != '\0')
+    {
+        std::snprintf(line, sizeof(line),
+            "ptr_hygiene tag=%s ptr=0x%016llX above32=%d %s",
+            tag != nullptr ? tag : "?",
+            static_cast<unsigned long long>(address),
+            above32,
+            extraTokens);
+    }
+    else
+    {
+        std::snprintf(line, sizeof(line),
+            "ptr_hygiene tag=%s ptr=0x%016llX above32=%d",
+            tag != nullptr ? tag : "?",
+            static_cast<unsigned long long>(address),
+            above32);
+    }
+    CoopRuntimeLog::Write(line);
+}
+
+void CoopPtrHygiene::CheckAbove32(const char* tag, const void* ptr)
+{
+    if (!g_enabled.load(std::memory_order_relaxed))
+        return;
+
+    const std::uintptr_t address = reinterpret_cast<std::uintptr_t>(ptr);
+    if ((address >> 32) == 0)
+        return;
+
+    char line[128];
+    std::snprintf(line, sizeof(line),
+        "ptr_hygiene_above32 tag=%s ptr=0x%016llX",
+        tag != nullptr ? tag : "?",
+        static_cast<unsigned long long>(address));
+    CoopRuntimeLog::WriteRateLimited(tag != nullptr ? tag : "ptr_hygiene_above32", line, 1.0, 3);
+}
+
+std::string CoopPtrHygiene::StatusReport()
+{
+    char report[128];
+    std::snprintf(report, sizeof(report),
+        "ptr_hygiene enabled=%d env=%d marker=%d explicit=%d",
+        Enabled() ? 1 : 0,
+        EnvFlagValue() ? 1 : 0,
+        MarkerFilePresent() ? 1 : 0,
+        g_explicitlySet.load(std::memory_order_relaxed) ? 1 : 0);
+    return report;
+}

--- a/CoopPrototype/Src/CoopPtrHygiene.h
+++ b/CoopPrototype/Src/CoopPtrHygiene.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+namespace CoopPtrHygiene
+{
+// Pointer-hygiene tracing for the water "sink" / water-item / healing-item
+// crash dissection.
+//
+// On native Windows the game silently hard-crashes on those paths while the
+// same session works on Proton. Working hypothesis: a 64->32 bit pointer
+// truncation that Proton's lower address space masks. When enabled, every
+// suspect hop logs full-width (16-hex-digit) pointer values so a truncated
+// value becomes visible in Game.log and in the crash-trace recent_mod_log
+// ring.
+//
+// Enabling (any of):
+//   * env var COOP_PTR_HYGIENE=1 before process start
+//   * marker file %USERPROFILE%\Saved Games\Arkane Studios\Prey\CoopPtrHygiene.txt
+//     (re-checked every 2 s from the render end-frame tick)
+//   * in-game console command: coop_ptr_hygiene on|off|status
+//
+// Cost when disabled: one atomic load per call site; no file I/O, no
+// allocations, no logging. Tick() does a stat() at most every 2 s only while
+// tracing could still change state.
+//
+// All output is greppable: single-space separated key=value tokens, pointer
+// values always 16 hex digits (ptr=0x%016llX). Output goes through
+// CoopRuntimeLog::Write (the same call LogCoop() in ModMain.cpp wraps), so
+// lines land in Game.log and in the crash-trace ring buffer.
+
+// Reads the env flag + marker file once and sets the initial enabled state.
+// Idempotent: only the first call computes the state (hot reloads must not
+// clobber a runtime coop_ptr_hygiene on/off decision).
+void Initialize();
+
+bool Enabled();
+void SetEnabled(bool enabled);
+
+// Cheap per-frame call (render end frame). Re-checks the marker file at most
+// every 2 seconds: marker appearing enables tracing; marker disappearing
+// disables tracing only when it was never explicitly set and the env flag is
+// not set.
+void Tick();
+
+// When enabled, logs:
+//   ptr_hygiene tag=<tag> ptr=0x%016llX above32=<0|1>
+void LogPtr(const char* tag, const void* ptr);
+
+// Same line plus pre-formatted extra "key=value" tokens (no leading space),
+// e.g. extraTokens = "active=1 force=0 playerInitiated=1". Pass nullptr or
+// "" for LogPtr behavior.
+void LogPtrWith(const char* tag, const void* ptr, const char* extraTokens);
+
+// When enabled and ((uintptr_t)ptr >> 32) != 0, emits via
+// CoopRuntimeLog::WriteRateLimited (key=<tag>, 1.0 s window, burst 3):
+//   ptr_hygiene_above32 tag=<tag> ptr=0x%016llX
+// Never fails, never asserts.
+void CheckAbove32(const char* tag, const void* ptr);
+
+// "enabled=<0|1> env=<0|1> marker=<0|1> explicit=<0|1>" for the status
+// command.
+std::string StatusReport();
+}

--- a/CoopPrototype/Src/CoopRuntimeLog.cpp
+++ b/CoopPrototype/Src/CoopRuntimeLog.cpp
@@ -3,9 +3,12 @@
 #include "ModMain.h"
 #include "CoopRuntimeConfig.h"
 
+#include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <cstddef>
+#include <cstring>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -26,12 +29,42 @@ std::unordered_map<std::string, RateLimitState> g_rateLimits;
 std::unordered_map<std::string, RateLimitState> g_repeatLimits;
 std::atomic<uint64_t> g_suppressedCount = 0;
 
+// Lock-free recent-line ring for crash traces (see RecentLines in the
+// header). No mutexes: the crash handler may run on a faulting thread where
+// a locked mutex could deadlock. Fixed slots, atomic sequence index, length
+// published with release after the text copy (a mid-copy crash leaves the
+// previous line's length, so readers never see a torn length).
+constexpr std::size_t kRingSlots = 512;
+constexpr std::size_t kRingLineCapacity = 128;
+
+struct LogRingSlot
+{
+    char text[kRingLineCapacity] = {};
+    std::atomic<std::uint16_t> length{0};
+};
+
+std::atomic<uint64_t> g_ringSequence{0};
+std::array<LogRingSlot, kRingSlots> g_ringSlots{};
+
+void RecordRingLine(std::string_view message)
+{
+    const uint64_t sequence = g_ringSequence.fetch_add(1, std::memory_order_relaxed);
+    LogRingSlot& slot = g_ringSlots[sequence % kRingSlots];
+    const std::size_t copyLength =
+        std::min<std::size_t>(message.size(), kRingLineCapacity - 1);
+    if (copyLength > 0)
+        std::memcpy(slot.text, message.data(), copyLength);
+    slot.text[copyLength] = '\0';
+    slot.length.store(static_cast<std::uint16_t>(copyLength), std::memory_order_release);
+}
+
 constexpr std::size_t kMaxRepeatKeys = 512;
 constexpr double kRepeatWindowSeconds = 2.0;
 constexpr uint32_t kRepeatBurst = 3;
 
 void WriteRaw(std::string_view message)
 {
+    RecordRingLine(message);
     if (gMod)
         gMod->RecordRuntimeLogEmission();
     CryLog("[CoopPrototype] {}", message);
@@ -137,4 +170,28 @@ void CoopRuntimeLog::ResetRateLimits()
     g_rateLimits.clear();
     g_repeatLimits.clear();
     g_suppressedCount = 0;
+}
+
+std::string CoopRuntimeLog::RecentLines(std::size_t maxLines)
+{
+    if (maxLines == 0)
+        return {};
+
+    const uint64_t next = g_ringSequence.load(std::memory_order_relaxed);
+    const uint64_t available = next < kRingSlots ? next : static_cast<uint64_t>(kRingSlots);
+    const uint64_t take = std::min<uint64_t>(maxLines, available);
+    std::string out;
+    if (take > 0)
+        out.reserve(take * 24);
+    // Oldest to newest so the returned order is newest-last.
+    for (uint64_t i = take; i > 0; --i)
+    {
+        const LogRingSlot& slot = g_ringSlots[(next - i) % kRingSlots];
+        const std::uint16_t length = slot.length.load(std::memory_order_acquire);
+        if (length == 0)
+            continue;
+        out.append(slot.text, length);
+        out.push_back('\n');
+    }
+    return out;
 }

--- a/CoopPrototype/Src/CoopRuntimeLog.h
+++ b/CoopPrototype/Src/CoopRuntimeLog.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
+#include <string>
 #include <string_view>
 
 namespace CoopRuntimeLog
@@ -13,4 +15,19 @@ bool WriteRateLimited(
     uint32_t burst = 1);
 uint64_t SuppressedCount();
 void ResetRateLimits();
+
+// Lock-free bounded ring of the most recent raw log lines, for crash traces.
+//
+// The crash / purecall / invalid-parameter handlers may run on a faulting
+// thread where taking the rate-limit mutex could deadlock, so this ring uses
+// no locks and no write-path allocations: fixed-size slots with atomic
+// sequence + length. Every line that reaches WriteRaw is recorded (long
+// lines are truncated to fit the slot).
+//
+// Returns up to maxLines of the most recent lines, newest last, each line
+// terminated by '\n'. Empty string if nothing has been recorded. Safe to
+// call from a SEH/vectored exception handler (atomic loads + memcpy only;
+// the returned std::string allocation is the only allocation and happens on
+// the handler thread, exactly like the existing trace-file path).
+std::string RecentLines(std::size_t maxLines);
 }

--- a/CoopPrototype/Src/ModMain.cpp
+++ b/CoopPrototype/Src/ModMain.cpp
@@ -4,6 +4,7 @@
 #include "CoopSerialSequence.h"
 #include "CoopRuntimeLog.h"
 #include "CoopRuntimeConfig.h"
+#include "CoopPtrHygiene.h"
 #include "CoopDamagePolicy.h"
 #include "CoopCampaignAreaFacts.generated.h"
 #include "CoopCampaignStoryFacts.generated.h"
@@ -1418,6 +1419,8 @@ bool ShouldTraceCrashException(DWORD code)
     case EXCEPTION_PRIV_INSTRUCTION:
     case EXCEPTION_STACK_OVERFLOW:
     case EXCEPTION_DATATYPE_MISALIGNMENT:
+    case 0xE0667422:  // C++ EH (uncaught exception / abort raised by game code)
+    case 0xC0000602:  // STATUS_FAST_FAIL_EXCEPTION (ucrtbase abort path)
         return true;
     default:
         return false;
@@ -1660,6 +1663,21 @@ void AppendCurrentStack(std::ostringstream& out)
         out << "  #" << i << " " << DescribeRuntimeAddress(frames[i]) << "\n";
 }
 
+// Appended to the end of every crash trace. The ring buffer is lock-free, so
+// this is safe to run on a faulting thread; m_lastAreaObjectEvent is read
+// best-effort, exactly like the other breadcrumb fields above.
+void AppendCrashTraceHygieneSections(std::ostringstream& out)
+{
+    if (gMod)
+        out << "last_area_object_event=" << gMod->GetLastAreaObjectEvent() << "\n";
+    const std::string recent = CoopRuntimeLog::RecentLines(150);
+    out << "recent_mod_log:\n";
+    if (recent.empty())
+        out << "  (empty)\n";
+    else
+        out << recent;
+}
+
 std::string WideTraceString(const wchar_t* text)
 {
     if (!text || !text[0])
@@ -1723,6 +1741,8 @@ void __cdecl CoopInvalidParameterTraceHandler(
 
     AppendCurrentStack(out);
 
+    AppendCrashTraceHygieneSections(out);
+
     const std::string path = BuildInvalidParameterTracePath(traceIndex);
     WriteCrashTraceFile(path, out.str());
 
@@ -1769,6 +1789,8 @@ void __cdecl CoopPurecallTraceHandler()
 
     AppendCurrentStack(out);
 
+    AppendCrashTraceHygieneSections(out);
+
     const std::string path = BuildPurecallTracePath(traceIndex);
     WriteCrashTraceFile(path, out.str());
 
@@ -1786,7 +1808,14 @@ LONG WINAPI CoopCrashVectoredExceptionHandler(EXCEPTION_POINTERS* pointers)
     if (!ShouldTraceCrashException(record.ExceptionCode))
         return EXCEPTION_CONTINUE_SEARCH;
 
-    if (CoopRuntimeGuards::IsGuardedCallbackActive())
+    const bool guardedCallbackActive = CoopRuntimeGuards::IsGuardedCallbackActive();
+    const bool abortExceptionCode =
+        record.ExceptionCode == 0xE0667422 ||  // C++ EH abort
+        record.ExceptionCode == 0xC0000602;    // STATUS_FAST_FAIL_EXCEPTION
+    // The game's variant-based process abort (GetDamagePosition et al.) raises
+    // these codes while a guarded callback is still on the stack; a guarded
+    // callback cannot catch them, so write the trace for abort codes anyway.
+    if (guardedCallbackActive && !abortExceptionCode)
         return EXCEPTION_CONTINUE_SEARCH;
 
     const LONG traceIndex = InterlockedIncrement(&g_crashTraceCount);
@@ -1826,12 +1855,18 @@ LONG WINAPI CoopCrashVectoredExceptionHandler(EXCEPTION_POINTERS* pointers)
         << " reason=" << guard.lastReason
         << "\n";
 
+    if (guardedCallbackActive)
+        out << "abort_in_guarded_callback code=" << Hex32(record.ExceptionCode)
+            << " op=" << guard.lastOperation << "\n";
+
     if (gMod)
         out << gMod->BuildCrashBreadcrumbs();
     else
         out << "coop_breadcrumbs unavailable: gMod=null\n";
 
     AppendFaultStack(out, pointers);
+
+    AppendCrashTraceHygieneSections(out);
 
     const std::string path = BuildCrashTracePath(traceIndex);
     WriteCrashTraceFile(path, out.str());
@@ -8464,6 +8499,15 @@ static void* GetArkInteractiveObjectExtensionFromEntity(IEntity* entity)
             extension,
             &reason) && extension)
     {
+        if (CoopPtrHygiene::Enabled())
+        {
+            char extra[96];
+            std::snprintf(extra, sizeof(extra), "gameObject=0x%016llX",
+                static_cast<unsigned long long>(reinterpret_cast<std::uintptr_t>(gameObject)));
+            CoopPtrHygiene::LogPtrWith("interactive_ext", extension, extra);
+            CoopPtrHygiene::CheckAbove32("interactive_ext", extension);
+            CoopPtrHygiene::CheckAbove32("interactive_ext_gameobject", gameObject);
+        }
         return extension;
     }
 
@@ -8474,6 +8518,15 @@ static void* GetArkInteractiveObjectExtensionFromEntity(IEntity* entity)
             extension,
             &reason) && extension)
     {
+        if (CoopPtrHygiene::Enabled())
+        {
+            char extra[96];
+            std::snprintf(extra, sizeof(extra), "gameObject=0x%016llX",
+                static_cast<unsigned long long>(reinterpret_cast<std::uintptr_t>(gameObject)));
+            CoopPtrHygiene::LogPtrWith("interactive_ext", extension, extra);
+            CoopPtrHygiene::CheckAbove32("interactive_ext", extension);
+            CoopPtrHygiene::CheckAbove32("interactive_ext_gameobject", gameObject);
+        }
         return extension;
     }
     return nullptr;
@@ -13443,13 +13496,28 @@ static bool IsLocalPlayerSurfaceHazardSignalRequest(
         return true;
     }
 
-    unsigned instigatorId = INVALID_ENTITYID;
-    return TryGuardedCall(
-               "ArkSurfaceHazard::OnReceiveSignal GetDamageInstigatorId",
-               [&package]() { return package.m_context.GetDamageInstigatorId(); },
-               instigatorId,
-               nullptr) &&
-        instigatorId == localPlayerId;
+    // The native GetDamageInstigatorId() aborts the process when the context
+    // variant does not hold a HitInfo const*, so read the payload directly:
+    // variant index 1 with a readable HitInfo, else instigator stays 0.
+    {
+        const ArkSignalSystem::CArkSignalContext& context = package.m_context;
+        const uint8_t* base = reinterpret_cast<const uint8_t*>(&context);
+        int32_t variantIndex = -1;
+        const void* payload = nullptr;
+        if (TryReadRuntimeValue(
+                reinterpret_cast<const int32_t const*>(base), variantIndex) &&
+            variantIndex == 1 &&
+            TryReadRuntimeValue(
+                reinterpret_cast<const void* const*>(base + 8), payload) &&
+            IsReadableRuntimePointer(payload, sizeof(HitInfo)))
+        {
+            const HitInfo* variantHitInfo = static_cast<const HitInfo*>(payload);
+            unsigned instigatorId = 0;
+            if (TryReadRuntimeValue(&variantHitInfo->shooterId, instigatorId))
+                return instigatorId == localPlayerId;
+        }
+    }
+    return false;
 }
 
 static void ArkSurfaceHazard_OnReceiveSignal_Hook(
@@ -19032,7 +19100,16 @@ static thread_local CArkItem* s_activeSharedDropClone = nullptr;
 
 static CArkItem& CArkItem_Clone_Hook(const CArkItem* item, int count)
 {
+    if (CoopPtrHygiene::Enabled())
+    {
+        char extra[64];
+        std::snprintf(extra, sizeof(extra), "count=%d", count);
+        CoopPtrHygiene::LogPtrWith("item_clone", item, extra);
+        CoopPtrHygiene::CheckAbove32("item_clone", item);
+    }
     CArkItem& clone = s_hookCArkItemClone.InvokeOrig(item, count);
+    if (CoopPtrHygiene::Enabled())
+        CoopPtrHygiene::LogPtr("item_clone_result", &clone);
     if (item && item == s_activeSharedDropSource)
         s_activeSharedDropClone = &clone;
     return clone;
@@ -19040,6 +19117,13 @@ static CArkItem& CArkItem_Clone_Hook(const CArkItem* item, int count)
 
 static void CArkItem_Drop_Hook(CArkItem* item, int dropCount, const Vec3* altPosition)
 {
+    if (CoopPtrHygiene::Enabled())
+    {
+        char extra[64];
+        std::snprintf(extra, sizeof(extra), "count=%d", dropCount);
+        CoopPtrHygiene::LogPtrWith("item_drop", item, extra);
+        CoopPtrHygiene::CheckAbove32("item_drop", item);
+    }
     const EntityId localPlayerId = ArkPlayer::GetInstancePtr()
         ? ArkPlayer::GetInstance().GetEntityId()
         : INVALID_ENTITYID;
@@ -19078,6 +19162,13 @@ static void CArkItem_Drop_Hook(CArkItem* item, int dropCount, const Vec3* altPos
 
 static bool CArkItem_PickUp_Hook(CArkItem* item, const unsigned pickerId, bool scaleOnLerp)
 {
+    if (CoopPtrHygiene::Enabled())
+    {
+        char extra[64];
+        std::snprintf(extra, sizeof(extra), "picker=%u", pickerId);
+        CoopPtrHygiene::LogPtrWith("item_pickup", item, extra);
+        CoopPtrHygiene::CheckAbove32("item_pickup", item);
+    }
     const EntityId itemEntityId = item ? item->GetEntityId() : INVALID_ENTITYID;
     if (gMod && gMod->ShouldDeferNativeSharedItemPickup(item, pickerId, "CArkItem::PickUp"))
         return false;
@@ -19090,6 +19181,13 @@ static bool CArkItem_PickUp_Hook(CArkItem* item, const unsigned pickerId, bool s
 
 static void CArkItem_ResetCount_Hook(CArkItem* item, int count)
 {
+    if (CoopPtrHygiene::Enabled())
+    {
+        char extra[64];
+        std::snprintf(extra, sizeof(extra), "count=%d", count);
+        CoopPtrHygiene::LogPtrWith("item_resetcount", item, extra);
+        CoopPtrHygiene::CheckAbove32("item_resetcount", item);
+    }
     s_hookCArkItemResetCount.InvokeOrig(item, count);
     if (gMod)
         gMod->OnArkItemResetCountHook(item, count);
@@ -19710,6 +19808,15 @@ static bool TryReadArkKeycardReaderLocked(ArkKeycardReader* reader, bool& locked
 
 static void ArkInteractiveObject_Activate_Hook(void* interactiveObject, bool active, bool force, bool playerInitiated)
 {
+    if (CoopPtrHygiene::Enabled())
+    {
+        char extra[96];
+        std::snprintf(extra, sizeof(extra), "active=%d force=%d playerInitiated=%d",
+            active ? 1 : 0, force ? 1 : 0, playerInitiated ? 1 : 0);
+        CoopPtrHygiene::LogPtrWith("interactive_activate", interactiveObject, extra);
+        CoopPtrHygiene::CheckAbove32("interactive_activate", interactiveObject);
+    }
+
     bool before = false;
     bool after = active;
     std::string reason;
@@ -19724,6 +19831,11 @@ static void ArkInteractiveObject_Activate_Hook(void* interactiveObject, bool act
     {
         IEntity* entity = TryGetArkInteractiveObjectEntity(
             interactiveObject, "area object interactive active entity", &reason);
+        if (CoopPtrHygiene::Enabled())
+        {
+            CoopPtrHygiene::LogPtr("interactive_activate_entity", entity);
+            CoopPtrHygiene::CheckAbove32("interactive_activate_entity", entity);
+        }
         gMod->OnLocalAreaObjectInteractiveObjectStateChanged(
             entity,
             CoopProtocol::kAreaObjectEventInteractiveObjectActive,
@@ -19735,6 +19847,15 @@ static void ArkInteractiveObject_Activate_Hook(void* interactiveObject, bool act
 
 static void ArkInteractiveObject_Disable_Hook(void* interactiveObject, bool disabled, bool force)
 {
+    if (CoopPtrHygiene::Enabled())
+    {
+        char extra[96];
+        std::snprintf(extra, sizeof(extra), "disabled=%d force=%d",
+            disabled ? 1 : 0, force ? 1 : 0);
+        CoopPtrHygiene::LogPtrWith("interactive_disable", interactiveObject, extra);
+        CoopPtrHygiene::CheckAbove32("interactive_disable", interactiveObject);
+    }
+
     bool before = false;
     bool after = disabled;
     std::string reason;
@@ -19749,6 +19870,11 @@ static void ArkInteractiveObject_Disable_Hook(void* interactiveObject, bool disa
     {
         IEntity* entity = TryGetArkInteractiveObjectEntity(
             interactiveObject, "area object interactive disabled entity", &reason);
+        if (CoopPtrHygiene::Enabled())
+        {
+            CoopPtrHygiene::LogPtr("interactive_disable_entity", entity);
+            CoopPtrHygiene::CheckAbove32("interactive_disable_entity", entity);
+        }
         gMod->OnLocalAreaObjectInteractiveObjectStateChanged(
             entity,
             CoopProtocol::kAreaObjectEventInteractiveObjectDisabled,
@@ -21055,11 +21181,28 @@ static void ArkPlayer_Ragdollize_Hook(ArkPlayer* player, const float verticalSpe
 
 static void ArkPlayerHealth_SetHealth_Hook(ArkPlayerHealthComponent* healthComponent, const float health, const bool damagedByRecyclerGrenade)
 {
+    if (CoopPtrHygiene::Enabled())
+    {
+        char extra[96];
+        std::snprintf(extra, sizeof(extra), "health=%.3f recycler=%d",
+            health, damagedByRecyclerGrenade ? 1 : 0);
+        CoopPtrHygiene::LogPtrWith("player_health_set", healthComponent, extra);
+        CoopPtrHygiene::CheckAbove32("player_health_set", healthComponent);
+    }
+
     if (gMod && healthComponent)
         gMod->OnArkPlayerHealthDropObserved(healthComponent, health, damagedByRecyclerGrenade ? "health_set_recycler" : "health_set");
 
     if (gMod && healthComponent && gMod->ShouldSuppressArkPlayerHealthSet(healthComponent, health, damagedByRecyclerGrenade))
     {
+        if (CoopPtrHygiene::Enabled())
+        {
+            char line[128];
+            std::snprintf(line, sizeof(line),
+                "ptr_hygiene tag=player_health_set_suppressed health=%.3f recycler=%d",
+                health, damagedByRecyclerGrenade ? 1 : 0);
+            LogCoop(line);
+        }
         gMod->OnArkPlayerHealthSetSuppressed(healthComponent, health, damagedByRecyclerGrenade);
         return;
     }
@@ -30264,6 +30407,11 @@ std::string ModMain::BuildCrashBreadcrumbs() const
     return out.str();
 }
 
+std::string ModMain::GetLastAreaObjectEvent() const
+{
+    return m_lastAreaObjectEvent;
+}
+
 void ModMain::AppendSpatialEntityTraceDetails(std::ostringstream& out, const char* logLine) const
 {
     GetEntitiesInBoxWarning warning;
@@ -30698,6 +30846,7 @@ void ModMain::UnregisterCoopRenderListener()
 
 void ModMain::OnCoopRenderEndFrame()
 {
+    CoopPtrHygiene::Tick();
     ++m_coopRenderEndFrameCalls;
 
     const float now = gEnv && gEnv->pTimer ? gEnv->pTimer->GetAsyncCurTime() : 0.0f;
@@ -31196,6 +31345,7 @@ void ModMain::InitHooks()
 void ModMain::InitSystem(const ModInitInfo& initInfo, ModDllInfo& dllInfo)
 {
     BaseClass::InitSystem(initInfo, dllInfo);
+    CoopPtrHygiene::Initialize();
     LoadPersistentConfig();
     InstallCrashExceptionHandler();
     RegisterSystemEventListener();
@@ -50880,6 +51030,36 @@ bool ModMain::HandleRuntimeControlCommand(const std::string& command, const std:
         m_networkStatus = "queued runtime unstuck";
         action = "unstuck_to_remote";
     }
+    else if (command == "coop_ptr_hygiene")
+    {
+        const std::string mode = args.empty() ? std::string("status") : ToLowerAscii(args.front());
+        if (mode == "on")
+        {
+            CoopPtrHygiene::SetEnabled(true);
+            action = "ptr_hygiene_on";
+            m_networkStatus = "ptr_hygiene tracing enabled";
+            LogCoop("ptr_hygiene enabled via runtime command");
+        }
+        else if (mode == "off")
+        {
+            CoopPtrHygiene::SetEnabled(false);
+            action = "ptr_hygiene_off";
+            m_networkStatus = "ptr_hygiene tracing disabled";
+            LogCoop("ptr_hygiene disabled via runtime command");
+        }
+        else if (mode == "status")
+        {
+            action = "ptr_hygiene_status";
+            commandDetail = CoopPtrHygiene::StatusReport();
+            m_networkStatus = "ptr_hygiene status";
+        }
+        else
+        {
+            ok = false;
+            action = "ptr_hygiene_usage";
+            m_networkStatus = "usage coop_ptr_hygiene on|off|status";
+        }
+    }
     else
     {
         ok = false;
@@ -58966,6 +59146,13 @@ void ModMain::OnLocalAreaObjectInteractiveObjectStateChanged(
             "_reason_" + StatusToken(guardReason.empty() ? std::string("-") : guardReason);
         return;
     }
+    if (CoopPtrHygiene::Enabled())
+    {
+        char extra[96];
+        std::snprintf(extra, sizeof(extra), "guid=%llu kind=%u value=%d",
+            static_cast<unsigned long long>(guid), static_cast<unsigned>(eventKind), value ? 1 : 0);
+        CoopPtrHygiene::LogPtrWith("area_interactive_state_changed", entity, extra);
+    }
     QueueLocalAreaObjectEventForHook(eventKind, guid, value ? 1u : 0u, 0, reason);
 }
 
@@ -61394,6 +61581,31 @@ bool ModMain::QueueLocalAreaObjectEventForHook(
         "_save_" + std::to_string(packet.hostSaveKeyHash) +
         "_reason_" + StatusToken(reason && reason[0] ? std::string(reason) : std::string("-"));
     LogCoop(m_lastAreaObjectEvent);
+    if (CoopPtrHygiene::Enabled() &&
+        (packet.eventKind == CoopProtocol::kAreaObjectEventInteractiveObjectActive ||
+            packet.eventKind == CoopProtocol::kAreaObjectEventInteractiveObjectDisabled))
+    {
+        // Full packet field dump for the suspect interactive-object kinds:
+        // 64-bit fields in 16-hex so a truncated value is visible.
+        char line[512];
+        std::snprintf(line, sizeof(line),
+            "ptr_hygiene tag=area_object_event_sent kind=%u value=%u flags=%u count=%d event=0x%016llX areaRevision=%u worldEpoch=%u hostSaveKeyHash=0x%016llX levelId=0x%016llX sourcePeerHash=0x%016llX targetGuid=0x%016llX targetClassHash=0x%016llX preVersion=%u postVersion=%u",
+            static_cast<unsigned>(packet.eventKind),
+            static_cast<unsigned>(packet.value),
+            static_cast<unsigned>(packet.flags),
+            packet.count,
+            static_cast<unsigned long long>(packet.eventId),
+            static_cast<unsigned>(packet.areaRevision),
+            static_cast<unsigned>(packet.worldEpoch),
+            static_cast<unsigned long long>(packet.hostSaveKeyHash),
+            static_cast<unsigned long long>(packet.levelId),
+            static_cast<unsigned long long>(packet.sourcePeerHash),
+            static_cast<unsigned long long>(packet.targetGuid),
+            static_cast<unsigned long long>(packet.targetClassHash),
+            static_cast<unsigned>(packet.preVersion),
+            static_cast<unsigned>(packet.postVersion));
+        LogCoop(line);
+    }
     return true;
 }
 
@@ -63672,6 +63884,13 @@ bool ModMain::ApplyAreaObjectEventMutation(const CoopProtocol::AreaObjectEventPa
         packet.eventKind == CoopProtocol::kAreaObjectEventInteractiveObjectDisabled)
     {
         void* interactiveObject = GetArkInteractiveObjectExtensionFromEntity(entity);
+        if (CoopPtrHygiene::Enabled())
+        {
+            CoopPtrHygiene::LogPtr("area_apply_interactive_entity", entity);
+            CoopPtrHygiene::CheckAbove32("area_apply_interactive_entity", entity);
+            CoopPtrHygiene::LogPtr("area_apply_interactive_ext", interactiveObject);
+            CoopPtrHygiene::CheckAbove32("area_apply_interactive_ext", interactiveObject);
+        }
         if (!interactiveObject)
         {
             detail = "missing_arkinteractiveobject_extension_guid_" + std::to_string(packet.targetGuid);
@@ -63712,6 +63931,18 @@ bool ModMain::ApplyAreaObjectEventMutation(const CoopProtocol::AreaObjectEventPa
             after,
             activeState ? "area object apply interactive active after" : "area object apply interactive disabled after",
             &reason);
+        if (CoopPtrHygiene::Enabled())
+        {
+            char extra[128];
+            std::snprintf(extra, sizeof(extra),
+                "kind=%u guid=%llu desired=%d before=%d after=%d",
+                static_cast<unsigned>(packet.eventKind),
+                static_cast<unsigned long long>(packet.targetGuid),
+                desired ? 1 : 0,
+                before ? 1 : 0,
+                after ? 1 : 0);
+            CoopPtrHygiene::LogPtrWith("area_apply_interactive_state", interactiveObject, extra);
+        }
         detail = callOk && after == desired
             ? (std::string("applied_interactive_object_") + (activeState ? "active_" : "disabled_") +
                 std::to_string(desired ? 1 : 0) + "_id_" + std::to_string(entityId))

--- a/CoopPrototype/Src/ModMain.h
+++ b/CoopPrototype/Src/ModMain.h
@@ -754,6 +754,7 @@ public:
     void OnAnimationQueueLogLine(const char* text, bool newLine);
     void OnPhysicalWorldGetEntitiesInBoxHook(const Vec3& ptmin, const Vec3& ptmax, int objtypes, int szListPrealloc);
     std::string BuildCrashBreadcrumbs() const;
+    std::string GetLastAreaObjectEvent() const;
     bool ShouldSuppressNativeSpawnInstrumentation() const noexcept;
     bool ShouldTraceNativeNpcSpawn() const;
 


### PR DESCRIPTION
Fixes #1
Fixes #3

### Summary of Changes
- **Signal Context Safety:** Replaced native accessor calls with `TryGetSignalContextHitInfo()` in `CoopPlayerState.cpp` and `ModMain.cpp` to safely read variant payloads directly and skip invalid getters for non-damage signals.
- **Crash Handler Coverage:** Updated the vectored exception handler in `ModMain.cpp` to trace C++ EH (`0xE0667422`) and `STATUS_FAST_FAIL_EXCEPTION` (`0xC0000602`) aborts even inside guarded callbacks.
- **Lock-free Log Ring Buffer:** Implemented `CoopRuntimeLog::RecentLines` so crash dumps include the last 150 log entries without deadlocking on faulting threads.
- **Pointer Hygiene Tracing (`CoopPtrHygiene`):** Added opt-in diagnostic tracing (`coop_ptr_hygiene`, `COOP_PTR_HYGIENE=1`, or marker file) to track 64-bit pointer usage and high-order bit truncation across healing, player vital, item, and interactive object hooks.