### PR TITLE
Properly generate cmake toolchain via cargo-xwin env

### DIFF
--- a/build-msvc.sh
+++ b/build-msvc.sh
@@ -48,10 +48,11 @@ podman run --rm --security-opt label=disable \
 set -euo pipefail
 ulimit -s unlimited
 
+target=x86_64-pc-windows-msvc
 toolchain=/root/.cache/cargo-xwin/cmake/clang-cl/x86_64-pc-windows-msvc-toolchain.cmake
 if [[ ! -f "$toolchain" ]] ||
    [[ ! -f /root/.cache/cargo-xwin/xwin/DONE ]]; then
-    /usr/local/cargo/bin/cargo-xwin cache xwin
+    /usr/local/cargo/bin/cargo-xwin env --target=$target >/dev/null
 fi
 
 if [[ ! -f _deps/detours-install/lib/detours.lib ]]; then
@@ -64,7 +65,7 @@ if [[ ! -f _deps/detours-install/lib/detours.lib ]]; then
     cp "$src/detours.h" "$src/detver.h" "$out/include/detours/"
 
     common=(
-        --target=x86_64-pc-windows-msvc
+        --target=$target
         -Wno-unused-command-line-argument
         -fuse-ld=lld-link
         /nologo /W4 /Zi /MD /Gy /O2


### PR DESCRIPTION
`cargo-xwin`'s `cache` command [just downloads](https://github.com/rust-cross/cargo-xwin/blob/650cbf243eed9d691eb533df17304fc2bbc00516/src/cache.rs#L83) MSVC's CRT and SDK.

Currently, the only way to have the CMake toolchain file [generated](https://github.com/rust-cross/cargo-xwin/blob/650cbf243eed9d691eb533df17304fc2bbc00516/src/compiler/clang_cl.rs#L210) by `cargo-xwin` is via `apply_cmd_env`.

This PR replaces the `cargo-xwin cache` command in the Linux build script with `cargo-xwin env` (as it doesn't depend on a manifest being in the repo), which will create the CMake toolchain file.