### PR TITLE
Fix Windows guarded-read VirtualQuery bottleneck

### DIFF
--- a/CoopPrototype/CMakeLists.txt
+++ b/CoopPrototype/CMakeLists.txt
@@ -58,3 +58,14 @@ add_subdirectory(CommonMod)
 
 # Mods
 add_subdirectory(Src)
+
+# Hardware faults must reach the SEH filters used by runtime reads. Keep /EHa
+# and the matching PCH exclusion scoped to the guard implementation only.
+set_property(SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/Src/CoopRuntimeGuards.cpp"
+	TARGET_DIRECTORY CoopPrototype
+	APPEND PROPERTY COMPILE_OPTIONS /EHa
+)
+set_property(SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/Src/CoopRuntimeGuards.cpp"
+	TARGET_DIRECTORY CoopPrototype
+	PROPERTY SKIP_PRECOMPILE_HEADERS ON
+)

--- a/CoopPrototype/Src/CMakeLists.txt
+++ b/CoopPrototype/Src/CMakeLists.txt
@@ -84,6 +84,8 @@ set(SOURCE_FILES
 	CoopRuntimeExtractor.h
 	CoopRuntimeGuards.cpp
 	CoopRuntimeGuards.h
+	CoopHookStats.cpp
+	CoopHookStats.h
 	CoopRuntimeLog.cpp
 	CoopRuntimeLog.h
 	CoopRuntimeConfig.cpp

--- a/CoopPrototype/Src/CoopHookStats.cpp
+++ b/CoopPrototype/Src/CoopHookStats.cpp
@@ -1,0 +1,84 @@
+#include "CoopHookStats.h"
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace CoopHookStats
+{
+namespace
+{
+constexpr std::size_t kMaxSlots = 48;
+
+std::vector<std::unique_ptr<Slot>>& Registry()
+{
+    static std::vector<std::unique_ptr<Slot>> registry;
+    return registry;
+}
+
+uint64_t NowNs()
+{
+    using namespace std::chrono;
+    return static_cast<uint64_t>(
+        duration_cast<nanoseconds>(steady_clock::now().time_since_epoch()).count());
+}
+}
+
+Slot* Register(const char* name)
+{
+    auto& registry = Registry();
+    if (registry.size() >= kMaxSlots || !name || !name[0])
+        return nullptr;
+    registry.push_back(std::make_unique<Slot>());
+    Slot& slot = *registry.back();
+    slot.name = name;
+    return &slot;
+}
+
+Scoped::Scoped(Slot* slot)
+    : m_slot(slot)
+    , m_startNs(NowNs())
+{
+}
+
+Scoped::~Scoped()
+{
+    if (!m_slot)
+        return;
+    const uint64_t elapsed = NowNs() - m_startNs;
+    m_slot->calls.fetch_add(1, std::memory_order_relaxed);
+    m_slot->totalNs.fetch_add(elapsed, std::memory_order_relaxed);
+}
+
+std::string BuildReport()
+{
+    auto& registry = Registry();
+    std::string out;
+    for (const auto& slotPtr : registry)
+    {
+        const Slot& slot = *slotPtr;
+        const uint64_t calls = slot.calls.load(std::memory_order_relaxed);
+        if (calls == 0)
+            continue;
+        const uint64_t ns = slot.totalNs.load(std::memory_order_relaxed);
+        if (!out.empty())
+            out += '|';
+        out += slot.name;
+        out += ':';
+        out += std::to_string(calls);
+        out += ':';
+        out += std::to_string(ns / 1000); // microseconds
+    }
+    return out;
+}
+
+void ResetAll()
+{
+    for (auto& slotPtr : Registry())
+    {
+        slotPtr->calls.store(0, std::memory_order_relaxed);
+        slotPtr->totalNs.store(0, std::memory_order_relaxed);
+    }
+}
+}

--- a/CoopPrototype/Src/CoopHookStats.h
+++ b/CoopPrototype/Src/CoopHookStats.h
@@ -1,0 +1,51 @@
+#pragma once
+//
+// CoopHookStats — feather-light self-profiling for the native hooks.
+//
+// Every instrumented hook contributes two atomic counters (call count +
+// cumulative nanoseconds). BuildRuntimeCostReport() dumps the aggregate into
+// the extractor status line / Game.log so any machine — including players'
+// high-end rigs — can report exactly where mod frame time goes without any
+// external tooling.
+//
+// Overhead per instrumented call is one QPC read + two relaxed atomic adds
+// (~15-25 ns), which is noise even at 10k calls/frame.
+//
+
+#include <atomic>
+#include <cstdint>
+
+namespace CoopHookStats
+{
+struct Slot
+{
+    const char* name = nullptr;
+    mutable std::atomic<uint64_t> calls{0};
+    mutable std::atomic<uint64_t> totalNs{0};
+};
+
+// Registers a named slot once (call from a static initializer).
+// Returns nullptr if the registry is full.
+Slot* Register(const char* name);
+
+// RAII scope timer bound to a registered slot.
+class Scoped
+{
+public:
+    explicit Scoped(Slot* slot);
+    ~Scoped();
+    Scoped(const Scoped&) = delete;
+    Scoped& operator=(const Scoped&) = delete;
+
+private:
+    Slot* m_slot = nullptr;
+    uint64_t m_startNs = 0;
+};
+
+// Formatted "name:calls:us" entries for every slot with calls > 0,
+// joined by '|'. Empty string when nothing has fired.
+std::string BuildReport();
+
+// Reset all counters (used between telemetry windows).
+void ResetAll();
+}

--- a/CoopPrototype/Src/CoopPlayerState.cpp
+++ b/CoopPrototype/Src/CoopPlayerState.cpp
@@ -945,6 +945,15 @@ void ModMain::OnArkSignalPackageObserved(
     const ArkSignalSystem::Package& package,
     const char* stage)
 {
+    // Cheap pre-check before any guarded (VirtualQuery-backed) reads below:
+    // the forwarded overload early-outs on these same conditions, so in
+    // offline / disabled states every guarded call here was pure overhead.
+    // This hook fires for EVERY signal package delivered to ANY receiver
+    // (lights, doors, physics props), so keep the offline path allocation-
+    // and syscall-free.
+    if (!m_damageDedupeEnabled || m_networkMode == CoopNetworkMode::Off)
+        return;
+
     uint64_t packageId = package.m_id;
     TryGuardedCall(
         "signal package GetId",

--- a/CoopPrototype/Src/CoopRuntimeGuards.cpp
+++ b/CoopPrototype/Src/CoopRuntimeGuards.cpp
@@ -11,10 +11,14 @@
 #endif
 
 #include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
-#include <chrono>
+#include <limits>
 #include <mutex>
+#include <string>
 
 namespace CoopRuntimeGuards
 {
@@ -38,6 +42,9 @@ struct RuntimeGuardState
 {
     std::mutex mutex;
     RuntimeGuardSnapshot snapshot;
+    // Lock-free per-call counter (issue #2): atomically incremented on every
+    // guarded call; folded into the snapshot by GetRuntimeGuardSnapshot.
+    std::atomic<uint64_t> guardedCallsAtomic{0};
 };
 
 thread_local int g_guardedCallbackDepth = 0;
@@ -46,6 +53,7 @@ struct SehCapture
 {
     unsigned code = 0;
     void* address = nullptr;
+    void* faultAddress = nullptr;
 };
 
 RuntimeGuardState& GetGuardState()
@@ -54,12 +62,78 @@ RuntimeGuardState& GetGuardState()
     return state;
 }
 
-// Self-profiling: total guarded-call time and VirtualQuery calls. These are
-// the Windows-only hot-path costs (under Wine/Proton VirtualQuery is a
-// user-space walk; on native Windows it is a kernel syscall per call), so we
+// Self-profiling: total guarded-call count/time and actual VirtualQuery API
+// calls. These are the Windows-only hot-path costs (under Wine/Proton
+// VirtualQuery is a user-space walk; on native Windows it is a kernel syscall
+// per call), so we
 // track them to quantify platform-specific overhead from telemetry alone.
 std::atomic<uint64_t> g_guardedCallTotalNs{0};
 std::atomic<uint64_t> g_virtualQueryCalls{0};
+
+// VirtualQuery timing is kept separate from the general guarded-call timer so
+// the release read fast path can prove that successful direct reads do not
+// enter VQ. Guard-page restoration uses these counters only on its failure
+// path.
+std::atomic<uint64_t> s_vqTotalNs{0};
+std::atomic<uint64_t> s_vqCalls{0};
+
+// Direct-read/object-probe experiment counters.  These stay lock-free on the
+// hot path and are folded into 10-second deltas by ModMain::MainUpdate.
+std::atomic<uint64_t> g_runtimeReadAttempts{0};
+std::atomic<uint64_t> g_runtimeReadFailures{0};
+std::atomic<uint64_t> g_runtimeReadAccessViolationFailures{0};
+std::atomic<uint64_t> g_runtimeReadInPageErrorFailures{0};
+std::atomic<uint64_t> g_runtimeReadGuardPageFailures{0};
+std::atomic<uint64_t> g_runtimeReadOtherFailures{0};
+std::atomic<uint32_t> g_runtimeReadLastExceptionCode{0};
+std::atomic<uint64_t> g_runtimeGuardRestoreAttempts{0};
+std::atomic<uint64_t> g_runtimeGuardRestoreSuccesses{0};
+std::atomic<uint64_t> g_runtimeGuardRestoreFailures{0};
+std::atomic<uint64_t> g_runtimeGuardRestoreAlreadyPresent{0};
+std::atomic<uint64_t> g_runtimeObjectProbeAttempts{0};
+std::atomic<uint64_t> g_runtimeObjectProbeFailures{0};
+
+// Per-operation guard cost attribution: fixed bucket table keyed by the
+// operation-name pointer identity (all call sites pass string literals).
+// Lock-free; a few ns per guarded call.
+constexpr std::size_t kGuardOpBuckets = 32;
+struct GuardOpBucket
+{
+    std::atomic<const char*> name{nullptr};
+    std::atomic<uint64_t> calls{0};
+    std::atomic<uint64_t> totalNs{0};
+    std::atomic<uint64_t> successes{0};
+    std::atomic<uint64_t> failures{0};
+    std::atomic<uint64_t> failNs{0};
+    std::atomic<uint32_t> lastExceptionCode{0};
+};
+GuardOpBucket g_guardOpBuckets[kGuardOpBuckets];
+
+GuardOpBucket* GuardOpSlot(const char* name)
+{
+    if (!name || !name[0])
+        name = "?";
+    std::size_t hash = 1469598103934665603ull;
+    for (const char* c = name; *c; ++c)
+    {
+        hash ^= static_cast<unsigned char>(*c);
+        hash *= 1099511628211ull;
+    }
+    const std::size_t first = hash % kGuardOpBuckets;
+    for (std::size_t probe = 0; probe < kGuardOpBuckets; ++probe)
+    {
+        GuardOpBucket& bucket = g_guardOpBuckets[(first + probe) % kGuardOpBuckets];
+        if (bucket.name.load(std::memory_order_acquire) == name)
+            return &bucket;
+        const char* expected = nullptr;
+        if (bucket.name.load(std::memory_order_acquire) == nullptr &&
+            bucket.name.compare_exchange_strong(expected, name))
+        {
+            return &bucket;
+        }
+    }
+    return nullptr;
+}
 
 uint64_t GuardTelemetryNowNs()
 {
@@ -97,12 +171,301 @@ std::string ExceptionCodeString(unsigned code)
     return buffer;
 }
 
+int RuntimeReadExceptionFilter(unsigned code, EXCEPTION_POINTERS* pointers, SehCapture* outCapture);
+
+enum class RuntimeReadMode
+{
+    VqPreflight,
+    Direct,
+};
+
+RuntimeReadMode GetRuntimeReadMode()
+{
+    // This is intentionally read once per process. It keeps environment lookup
+    // and string work out of the hot path. Release uses direct SEH reads by
+    // default; the VQ mode is retained as an explicit A/B fallback.
+    static const RuntimeReadMode mode = [] {
+        char value[16] = {};
+        const DWORD length = GetEnvironmentVariableA(
+            "COOP_RUNTIME_READ_MODE", value, static_cast<DWORD>(sizeof(value)));
+        if (length > 0 && length < sizeof(value) && std::strcmp(value, "vq") == 0)
+            return RuntimeReadMode::VqPreflight;
+        return RuntimeReadMode::Direct;
+    }();
+    return mode;
+}
+
+enum class RuntimeObjectProbeMode
+{
+    VqPreflight,
+    Direct,
+};
+
+enum class RuntimeGuardPagePolicy
+{
+    Preserve,
+    AllowConsume,
+};
+
+RuntimeObjectProbeMode GetRuntimeObjectProbeMode()
+{
+    static const RuntimeObjectProbeMode mode = [] {
+        char value[16] = {};
+        const DWORD length = GetEnvironmentVariableA(
+            "COOP_RUNTIME_OBJECT_PROBE_MODE", value, static_cast<DWORD>(sizeof(value)));
+        if (length > 0 && length < sizeof(value) &&
+            (std::strcmp(value, "direct") == 0 || std::strcmp(value, "seh") == 0))
+            return RuntimeObjectProbeMode::Direct;
+        return RuntimeObjectProbeMode::VqPreflight;
+    }();
+    return mode;
+}
+
+RuntimeGuardPagePolicy GetRuntimeGuardPagePolicy()
+{
+    static const RuntimeGuardPagePolicy policy = [] {
+        char value[8] = {};
+        const DWORD length = GetEnvironmentVariableA(
+            "COOP_RUNTIME_ALLOW_GUARD_CONSUME", value, static_cast<DWORD>(sizeof(value)));
+        if (length == 1 && value[0] == '1')
+            return RuntimeGuardPagePolicy::AllowConsume;
+        return RuntimeGuardPagePolicy::Preserve;
+    }();
+    return policy;
+}
+
+SIZE_T CountedVirtualQuery(const void* pointer, MEMORY_BASIC_INFORMATION& memoryInfo)
+{
+    g_virtualQueryCalls.fetch_add(1, std::memory_order_relaxed);
+    const uint64_t startNs = GuardTelemetryNowNs();
+    const SIZE_T result = VirtualQuery(pointer, &memoryInfo, sizeof(memoryInfo));
+    s_vqTotalNs.fetch_add(GuardTelemetryNowNs() - startNs, std::memory_order_relaxed);
+    s_vqCalls.fetch_add(1, std::memory_order_relaxed);
+    return result;
+}
+
+void RestoreGuardPageAfterException(const SehCapture& capture)
+{
+    if (capture.code != EXCEPTION_GUARD_PAGE ||
+        GetRuntimeGuardPagePolicy() == RuntimeGuardPagePolicy::AllowConsume)
+    {
+        return;
+    }
+
+    g_runtimeGuardRestoreAttempts.fetch_add(1, std::memory_order_relaxed);
+    if (!capture.faultAddress)
+    {
+        g_runtimeGuardRestoreFailures.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+
+    // The OS consumes PAGE_GUARD before dispatching the exception. Query and
+    // restore only the page that faulted, and only on this rare failure path;
+    // successful direct reads never execute either API.
+    MEMORY_BASIC_INFORMATION memoryInfo = {};
+    if (CountedVirtualQuery(capture.faultAddress, memoryInfo) == 0 ||
+        memoryInfo.State != MEM_COMMIT || memoryInfo.Protect == 0)
+    {
+        g_runtimeGuardRestoreFailures.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+
+    if ((memoryInfo.Protect & PAGE_GUARD) != 0)
+    {
+        g_runtimeGuardRestoreAlreadyPresent.fetch_add(1, std::memory_order_relaxed);
+        g_runtimeGuardRestoreSuccesses.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+
+    DWORD oldProtect = 0;
+    if (VirtualProtect(
+        capture.faultAddress,
+        1,
+        memoryInfo.Protect | PAGE_GUARD,
+        &oldProtect) == FALSE)
+    {
+        g_runtimeGuardRestoreFailures.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+    g_runtimeGuardRestoreSuccesses.fetch_add(1, std::memory_order_relaxed);
+}
+
+bool UseDirectRuntimeRead()
+{
+    return GetRuntimeReadMode() == RuntimeReadMode::Direct;
+}
+
+bool UseDirectRuntimeObjectProbe()
+{
+    // Object probing remains VQ-backed by default. Direct probing is an
+    // independent, explicit experiment and does not silently broaden the
+    // release policy used by the typed value reader.
+    return GetRuntimeObjectProbeMode() == RuntimeObjectProbeMode::Direct;
+}
+
+void RecordRuntimeReadFailure(unsigned code)
+{
+    g_runtimeReadFailures.fetch_add(1, std::memory_order_relaxed);
+    g_runtimeReadLastExceptionCode.store(code, std::memory_order_relaxed);
+    switch (code)
+    {
+    case EXCEPTION_ACCESS_VIOLATION:
+        g_runtimeReadAccessViolationFailures.fetch_add(1, std::memory_order_relaxed);
+        break;
+    case EXCEPTION_IN_PAGE_ERROR:
+        g_runtimeReadInPageErrorFailures.fetch_add(1, std::memory_order_relaxed);
+        break;
+    case EXCEPTION_GUARD_PAGE:
+        g_runtimeReadGuardPageFailures.fetch_add(1, std::memory_order_relaxed);
+        break;
+    default:
+        g_runtimeReadOtherFailures.fetch_add(1, std::memory_order_relaxed);
+        break;
+    }
+}
+
+void RecordRuntimeObjectProbeFailure()
+{
+    g_runtimeObjectProbeFailures.fetch_add(1, std::memory_order_relaxed);
+}
+
+// Probe a runtime span without VirtualQuery in the explicit direct mode.
+// IsLikelyRuntimeCppObject is called from several hot hooks; the old
+// validation paid for a Windows VirtualQuery before subsequently reading the
+// same bytes under SEH. Touch only one byte per covered page (plus the final
+// byte) so large object-size checks do not become a second memcpy-sized hot
+// path. The default VQ mode remains conservative. Direct mode is an explicit
+// experiment and re-arms PAGE_GUARD after a guard exception unless the
+// separate COOP_RUNTIME_ALLOW_GUARD_CONSUME=1 opt-in is present.
+bool TryProbeRuntimeReadSeh(const void* pointer, size_t size)
+{
+    g_runtimeObjectProbeAttempts.fetch_add(1, std::memory_order_relaxed);
+    if (!pointer || size == 0)
+    {
+        RecordRuntimeObjectProbeFailure();
+        return false;
+    }
+
+    if (!UseDirectRuntimeObjectProbe())
+    {
+        const bool result = IsReadableRuntimePointer(pointer, size);
+        if (!result)
+            RecordRuntimeObjectProbeFailure();
+        return result;
+    }
+
+    const std::uintptr_t start = reinterpret_cast<std::uintptr_t>(pointer);
+    if (size > (std::numeric_limits<std::uintptr_t>::max)() - start)
+    {
+        RecordRuntimeObjectProbeFailure();
+        return false;
+    }
+    const std::uintptr_t last = start + size - 1;
+    static const std::uintptr_t pageSize = [] {
+        SYSTEM_INFO systemInfo = {};
+        GetSystemInfo(&systemInfo);
+        return static_cast<std::uintptr_t>(systemInfo.dwPageSize ? systemInfo.dwPageSize : 4096u);
+    }();
+
+    bool result = false;
+    SehCapture capture;
+    __try
+    {
+        volatile unsigned char observed = 0;
+        std::uintptr_t address = start;
+        for (;;)
+        {
+            const volatile unsigned char* byte =
+                reinterpret_cast<const volatile unsigned char*>(address);
+            observed = static_cast<unsigned char>(observed ^ *byte);
+
+            const std::uintptr_t pageOffset = address % pageSize;
+            const std::uintptr_t bytesToNextPage = pageSize - pageOffset;
+            if (bytesToNextPage > last - address)
+                break;
+            address += bytesToNextPage;
+        }
+        if (address != last)
+        {
+            const volatile unsigned char* finalByte =
+                reinterpret_cast<const volatile unsigned char*>(last);
+            observed = static_cast<unsigned char>(observed ^ *finalByte);
+        }
+        (void)observed;
+        result = true;
+    }
+    __except (RuntimeReadExceptionFilter(
+        GetExceptionCode(), GetExceptionInformation(), &capture))
+    {
+        result = false;
+    }
+    if (!result)
+    {
+        RestoreGuardPageAfterException(capture);
+        RecordRuntimeObjectProbeFailure();
+    }
+    return result;
+}
+
+constexpr size_t kRuntimeReadInlineBytes = 512;
+
+int RuntimeReadExceptionFilter(
+    unsigned code,
+    EXCEPTION_POINTERS* pointers,
+    SehCapture* outCapture)
+{
+    if (outCapture)
+    {
+        outCapture->code = code;
+        outCapture->address = pointers && pointers->ExceptionRecord
+            ? pointers->ExceptionRecord->ExceptionAddress
+            : nullptr;
+        if (code == EXCEPTION_GUARD_PAGE && pointers && pointers->ExceptionRecord &&
+            pointers->ExceptionRecord->NumberParameters >= 2)
+        {
+            outCapture->faultAddress = reinterpret_cast<void*>(
+                static_cast<std::uintptr_t>(pointers->ExceptionRecord->ExceptionInformation[1]));
+        }
+    }
+
+    switch (code)
+    {
+    case EXCEPTION_ACCESS_VIOLATION:
+    case EXCEPTION_IN_PAGE_ERROR:
+    case EXCEPTION_GUARD_PAGE:
+        return EXCEPTION_EXECUTE_HANDLER;
+    default:
+        return EXCEPTION_CONTINUE_SEARCH;
+    }
+}
+
+// The common reads are scalar values and fit in this per-thread scratch
+// buffer.  Larger reads use the process heap only when needed and retain the
+// allocation for the thread, so the hot path does not allocate per call.
+struct RuntimeReadScratch
+{
+    std::array<unsigned char, kRuntimeReadInlineBytes> inlineBytes{};
+    unsigned char* extendedBytes = nullptr;
+    size_t extendedCapacity = 0;
+
+    ~RuntimeReadScratch()
+    {
+        if (extendedBytes)
+            HeapFree(GetProcessHeap(), 0, extendedBytes);
+    }
+};
+
+RuntimeReadScratch& GetRuntimeReadScratch()
+{
+    thread_local RuntimeReadScratch scratch;
+    return scratch;
+}
+
 bool QueryRuntimeMemory(const void* pointer, size_t minBytes, RuntimeMemoryQuery& outQuery, std::string* outReason)
 {
     const auto value = reinterpret_cast<std::uintptr_t>(pointer);
     outQuery = {};
     outQuery.value = value;
-    g_virtualQueryCalls.fetch_add(1, std::memory_order_relaxed);
 
     if (value < 0x10000 || value == ~std::uintptr_t{ 0 })
     {
@@ -112,7 +475,8 @@ bool QueryRuntimeMemory(const void* pointer, size_t minBytes, RuntimeMemoryQuery
     }
 
     MEMORY_BASIC_INFORMATION memoryInfo = {};
-    if (VirtualQuery(pointer, &memoryInfo, sizeof(memoryInfo)) == 0)
+    const SIZE_T vqResult = CountedVirtualQuery(pointer, memoryInfo);
+    if (vqResult == 0)
     {
         if (outReason)
             *outReason = "VirtualQuery failed; address is not mapped in current process";
@@ -196,19 +560,25 @@ void RecordGuardPreflightFailure(
 
 void RecordGuardedCall(bool success, const char* operation, const std::string& reason, const SehCapture* seh)
 {
+    // Lock-free fast path (issue #2): this runs for EVERY guarded call on
+    // every thread. The original per-call mutex serialised all threads and,
+    // with ~11k guarded calls/second, blocked the main thread behind
+    // background telemetry bookkeeping (measured: main thread 91% blocked in
+    // ntdll wait). Counters are atomics now; the failure strings are only
+    // updated on failures (rare) under the mutex.
     RuntimeGuardState& state = GetGuardState();
+    state.guardedCallsAtomic.fetch_add(1, std::memory_order_relaxed);
+    if (success)
+        return;
+
     std::lock_guard<std::mutex> lock(state.mutex);
-    ++state.snapshot.guardedCalls;
-    if (!success)
-    {
-        ++state.snapshot.guardedCallFailures;
-        if (seh && seh->code != 0)
-            ++state.snapshot.sehExceptions;
-        state.snapshot.lastOperation = operation && operation[0] ? operation : "-";
-        state.snapshot.lastReason = reason;
-        state.snapshot.lastExceptionCode = seh ? seh->code : 0;
-        state.snapshot.lastExceptionAddress = seh ? reinterpret_cast<std::uintptr_t>(seh->address) : 0;
-    }
+    ++state.snapshot.guardedCallFailures;
+    if (seh && seh->code != 0)
+        ++state.snapshot.sehExceptions;
+    state.snapshot.lastOperation = operation && operation[0] ? operation : "-";
+    state.snapshot.lastReason = reason;
+    state.snapshot.lastExceptionCode = seh ? seh->code : 0;
+    state.snapshot.lastExceptionAddress = seh ? reinterpret_cast<std::uintptr_t>(seh->address) : 0;
 }
 
 int RuntimeGuardExceptionFilter(unsigned code, EXCEPTION_POINTERS* pointers, SehCapture* outCapture)
@@ -230,6 +600,133 @@ int RuntimeGuardExceptionFilter(unsigned code, EXCEPTION_POINTERS* pointers, Seh
     default:
         return EXCEPTION_CONTINUE_SEARCH;
     }
+}
+
+bool TryReadRuntimeValueImpl(const void* pointer, void* outValue, size_t size, bool validateOutput)
+{
+    g_runtimeReadAttempts.fetch_add(1, std::memory_order_relaxed);
+
+    if (!pointer || !outValue || size == 0)
+    {
+        RecordRuntimeReadFailure(0);
+        return false;
+    }
+
+    // Direct SEH is the release fast path. The old VQ preflight/copy path is
+    // retained behind COOP_RUNTIME_READ_MODE=vq for controlled A/B runs.
+    if (!UseDirectRuntimeRead() &&
+        !PreflightRuntimePointer("read runtime value", pointer, size, RuntimeAccess::Read))
+    {
+        RecordRuntimeReadFailure(0);
+        return false;
+    }
+
+    // Only the raw void* API validates its caller-owned destination. The
+    // typed wrapper passes a live local T and deliberately avoids this second
+    // VQ call; in explicit VQ mode it retains the original source-only
+    // preflight.
+    if (validateOutput &&
+        !PreflightRuntimePointer(
+            "read runtime value output", outValue, size, RuntimeAccess::Write))
+    {
+        RecordRuntimeReadFailure(0);
+        return false;
+    }
+
+    if (!validateOutput)
+    {
+        // The typed wrapper supplies a trusted, live local destination. A
+        // source fault can therefore leave this staging object partial while
+        // the caller's output remains untouched until this function returns
+        // successfully. This is also the one-copy direct fast path.
+        bool readComplete = false;
+        SehCapture capture;
+        __try
+        {
+            std::memcpy(outValue, pointer, size);
+            readComplete = true;
+        }
+        __except (RuntimeReadExceptionFilter(
+            GetExceptionCode(), GetExceptionInformation(), &capture))
+        {
+        }
+        if (!readComplete)
+        {
+            RestoreGuardPageAfterException(capture);
+            RecordRuntimeReadFailure(capture.code);
+        }
+        return readComplete;
+    }
+
+    RuntimeReadScratch& scratch = GetRuntimeReadScratch();
+    unsigned char* temporary = scratch.inlineBytes.data();
+    if (size > kRuntimeReadInlineBytes)
+    {
+        if (size > (std::numeric_limits<size_t>::max)() - 7u)
+        {
+            RecordRuntimeReadFailure(0);
+            return false;
+        }
+        const size_t requiredCapacity = (size + 7u) & ~size_t{ 7u };
+        if (requiredCapacity > scratch.extendedCapacity)
+        {
+            void* resized = scratch.extendedBytes
+                ? HeapReAlloc(GetProcessHeap(), 0, scratch.extendedBytes, requiredCapacity)
+                : HeapAlloc(GetProcessHeap(), 0, requiredCapacity);
+            if (!resized)
+            {
+                RecordRuntimeReadFailure(0);
+                return false;
+            }
+            scratch.extendedBytes = static_cast<unsigned char*>(resized);
+            scratch.extendedCapacity = requiredCapacity;
+        }
+        temporary = scratch.extendedBytes;
+    }
+
+    bool readComplete = false;
+    SehCapture readCapture;
+    __try
+    {
+        // The conservative path keeps the native copy after source VQ;
+        // staging protects the raw destination from source faults. Direct
+        // mode deliberately performs the same copy under MSVC SEH, without
+        // a source VQ.
+        std::memcpy(temporary, pointer, size);
+        readComplete = true;
+    }
+    __except (RuntimeReadExceptionFilter(
+        GetExceptionCode(), GetExceptionInformation(), &readCapture))
+    {
+    }
+
+    if (!readComplete)
+    {
+        RestoreGuardPageAfterException(readCapture);
+        RecordRuntimeReadFailure(readCapture.code);
+        return false;
+    }
+
+    bool commitComplete = false;
+    SehCapture commitCapture;
+    __try
+    {
+        std::memcpy(outValue, temporary, size);
+        commitComplete = true;
+    }
+    __except (RuntimeReadExceptionFilter(
+        GetExceptionCode(), GetExceptionInformation(), &commitCapture))
+    {
+    }
+    if (!commitComplete)
+    {
+        // The source is fully staged, but a raw destination can still race
+        // with protection/lifetime changes during this non-atomic commit.
+        RestoreGuardPageAfterException(commitCapture);
+        RecordRuntimeReadFailure(commitCapture.code);
+        return false;
+    }
+    return true;
 }
 
 bool TryRunGuardedCallbackRaw(RuntimeGuardCallback callback, void* context, SehCapture* outCapture)
@@ -256,6 +753,93 @@ bool TryRunGuardedCallbackRaw(RuntimeGuardCallback callback, void* context, SehC
     --g_guardedCallbackDepth;
     g_guardedCallTotalNs.fetch_add(GuardTelemetryNowNs() - startNs, std::memory_order_relaxed);
     return result;
+}
+}
+
+bool TryRuntimeReadProbeSeh(const void* pointer, size_t size)
+{
+    return TryProbeRuntimeReadSeh(pointer, size);
+}
+
+const char* RuntimeReadModeName()
+{
+    return GetRuntimeReadMode() == RuntimeReadMode::VqPreflight ? "vq" : "direct";
+}
+
+const char* RuntimeReadEffectiveModeName()
+{
+    return UseDirectRuntimeRead() ? "direct" : "vq";
+}
+
+const char* RuntimeObjectProbeModeName()
+{
+    return GetRuntimeObjectProbeMode() == RuntimeObjectProbeMode::VqPreflight ? "vq" : "direct";
+}
+
+const char* RuntimeObjectProbeEffectiveModeName()
+{
+    return UseDirectRuntimeObjectProbe() ? "direct" : "vq";
+}
+
+const char* RuntimeGuardPagePolicyName()
+{
+    return GetRuntimeGuardPagePolicy() == RuntimeGuardPagePolicy::Preserve
+        ? "preserve"
+        : "allowConsume";
+}
+
+RuntimeReadTelemetry GetRuntimeReadTelemetry()
+{
+    RuntimeReadTelemetry telemetry;
+    telemetry.attempts = g_runtimeReadAttempts.load(std::memory_order_relaxed);
+    telemetry.failures = g_runtimeReadFailures.load(std::memory_order_relaxed);
+    telemetry.accessViolationFailures =
+        g_runtimeReadAccessViolationFailures.load(std::memory_order_relaxed);
+    telemetry.inPageErrorFailures =
+        g_runtimeReadInPageErrorFailures.load(std::memory_order_relaxed);
+    telemetry.guardPageFailures =
+        g_runtimeReadGuardPageFailures.load(std::memory_order_relaxed);
+    telemetry.otherFailures = g_runtimeReadOtherFailures.load(std::memory_order_relaxed);
+    telemetry.guardPageRestoreAttempts =
+        g_runtimeGuardRestoreAttempts.load(std::memory_order_relaxed);
+    telemetry.guardPageRestoreSuccesses =
+        g_runtimeGuardRestoreSuccesses.load(std::memory_order_relaxed);
+    telemetry.guardPageRestoreFailures =
+        g_runtimeGuardRestoreFailures.load(std::memory_order_relaxed);
+    telemetry.guardPageRestoreAlreadyPresent =
+        g_runtimeGuardRestoreAlreadyPresent.load(std::memory_order_relaxed);
+    telemetry.lastExceptionCode = g_runtimeReadLastExceptionCode.load(std::memory_order_relaxed);
+    return telemetry;
+}
+
+RuntimeObjectProbeTelemetry GetRuntimeObjectProbeTelemetry()
+{
+    RuntimeObjectProbeTelemetry telemetry;
+    telemetry.attempts = g_runtimeObjectProbeAttempts.load(std::memory_order_relaxed);
+    telemetry.failures = g_runtimeObjectProbeFailures.load(std::memory_order_relaxed);
+    return telemetry;
+}
+
+uint64_t GetGuardVqCalls()
+{
+    return s_vqCalls.load(std::memory_order_relaxed);
+}
+
+uint64_t GetGuardVqTotalNs()
+{
+    return s_vqTotalNs.load(std::memory_order_relaxed);
+}
+
+bool TryReadRuntimeValueSeh(const void* pointer, void* outValue, size_t size)
+{
+    return TryReadRuntimeValueImpl(pointer, outValue, size, true);
+}
+
+namespace detail
+{
+bool TryReadRuntimeValueTrustedSeh(const void* pointer, void* outValue, size_t size)
+{
+    return TryReadRuntimeValueImpl(pointer, outValue, size, false);
 }
 }
 
@@ -377,14 +961,18 @@ std::string GetRuntimeModulePath(const void* pointer)
 
 bool IsLikelyRuntimeCppObject(const void* object, size_t minBytes)
 {
-    if (!IsReadableRuntimePointer(object, minBytes))
+    // This is separate from TryReadRuntimeValue's one-value fix: it removes
+    // the two read-side VirtualQuery preflights that object validation used
+    // to add around that read.  Write/execute checks retain their VQ-backed
+    // protection semantics because they cannot be replaced by a read probe.
+    if (!TryProbeRuntimeReadSeh(object, minBytes))
         return false;
 
     const void* vtable = nullptr;
     if (!TryReadRuntimeValue(reinterpret_cast<const void* const*>(object), vtable))
         return false;
 
-    return IsReadableRuntimePointer(vtable, sizeof(void*)) && IsRuntimePointerInLoadedModule(vtable);
+    return TryProbeRuntimeReadSeh(vtable, sizeof(void*)) && IsRuntimePointerInLoadedModule(vtable);
 }
 
 std::string ReadRuntimeCString(const char* pointer, size_t maxLength)
@@ -434,14 +1022,77 @@ GuardTelemetryTotals GetGuardTelemetryTotals()
     GuardTelemetryTotals totals;
     totals.guardedCallTotalNs = g_guardedCallTotalNs.load(std::memory_order_relaxed);
     totals.virtualQueryCalls = g_virtualQueryCalls.load(std::memory_order_relaxed);
+    const RuntimeGuardSnapshot snapshot = GetRuntimeGuardSnapshot();
+    totals.sehExceptions = snapshot.sehExceptions;
+    totals.guardedCallFailures = snapshot.guardedCallFailures;
+    totals.preflightFailures = snapshot.preflightFailures;
     return totals;
+}
+
+uint64_t GuardTelemetryNowNsPublic()
+{
+    return GuardTelemetryNowNs();
+}
+
+std::string GetGuardOpReport()
+{
+    struct Entry
+    {
+        const char* name;
+        uint64_t calls;
+        uint64_t ns;
+        uint64_t failures;
+        uint64_t failNs;
+    };
+    Entry entries[kGuardOpBuckets];
+    std::size_t count = 0;
+    for (GuardOpBucket& bucket : g_guardOpBuckets)
+    {
+        const char* name = bucket.name.load(std::memory_order_acquire);
+        if (!name)
+            continue;
+        if (count < kGuardOpBuckets)
+        {
+            entries[count++] = Entry{
+                name,
+                bucket.calls.load(std::memory_order_relaxed),
+                bucket.totalNs.load(std::memory_order_relaxed),
+                bucket.failures.load(std::memory_order_relaxed),
+                bucket.failNs.load(std::memory_order_relaxed)};
+        }
+    }
+    std::sort(entries, entries + count, [](const Entry& a, const Entry& b) { return a.ns > b.ns; });
+    std::string out;
+    const std::size_t limit = std::min<std::size_t>(count, 5);
+    for (std::size_t i = 0; i < limit; ++i)
+    {
+        if (entries[i].ns == 0)
+            break;
+        if (!out.empty())
+            out += '|';
+        out += entries[i].name;
+        out += ':';
+        out += std::to_string(entries[i].calls);
+        out += ':';
+        out += std::to_string(entries[i].ns / 1000);
+        out += ':';
+        out += std::to_string(entries[i].failures);
+        out += ':';
+        out += std::to_string(entries[i].failNs / 1000);
+    }
+    return out;
 }
 
 RuntimeGuardSnapshot GetRuntimeGuardSnapshot()
 {
     RuntimeGuardState& state = GetGuardState();
-    std::lock_guard<std::mutex> lock(state.mutex);
-    return state.snapshot;
+    RuntimeGuardSnapshot snapshot;
+    {
+        std::lock_guard<std::mutex> lock(state.mutex);
+        snapshot = state.snapshot;
+    }
+    snapshot.guardedCalls = state.guardedCallsAtomic.load(std::memory_order_relaxed);
+    return snapshot;
 }
 
 bool TryRunGuardedCallback(
@@ -450,8 +1101,25 @@ bool TryRunGuardedCallback(
     void* context,
     std::string* outReason)
 {
+    GuardOpBucket* opSlot = GuardOpSlot(operation);
+    const uint64_t opStartNs = GuardTelemetryNowNs();
     SehCapture seh = {};
     const bool success = TryRunGuardedCallbackRaw(callback, context, &seh);
+    if (opSlot)
+    {
+        const uint64_t opNs = GuardTelemetryNowNs() - opStartNs;
+        opSlot->calls.fetch_add(1, std::memory_order_relaxed);
+        opSlot->totalNs.fetch_add(opNs, std::memory_order_relaxed);
+        if (success)
+            opSlot->successes.fetch_add(1, std::memory_order_relaxed);
+        else
+        {
+            opSlot->failures.fetch_add(1, std::memory_order_relaxed);
+            opSlot->failNs.fetch_add(opNs, std::memory_order_relaxed);
+            if (seh.code != 0)
+                opSlot->lastExceptionCode.store(seh.code, std::memory_order_relaxed);
+        }
+    }
     if (success)
     {
         if (outReason)

--- a/CoopPrototype/Src/CoopRuntimeGuards.cpp
+++ b/CoopPrototype/Src/CoopRuntimeGuards.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstdio>
+#include <chrono>
 #include <mutex>
 
 namespace CoopRuntimeGuards
@@ -53,6 +54,20 @@ RuntimeGuardState& GetGuardState()
     return state;
 }
 
+// Self-profiling: total guarded-call time and VirtualQuery calls. These are
+// the Windows-only hot-path costs (under Wine/Proton VirtualQuery is a
+// user-space walk; on native Windows it is a kernel syscall per call), so we
+// track them to quantify platform-specific overhead from telemetry alone.
+std::atomic<uint64_t> g_guardedCallTotalNs{0};
+std::atomic<uint64_t> g_virtualQueryCalls{0};
+
+uint64_t GuardTelemetryNowNs()
+{
+    using namespace std::chrono;
+    return static_cast<uint64_t>(
+        duration_cast<nanoseconds>(steady_clock::now().time_since_epoch()).count());
+}
+
 const char* AccessName(RuntimeAccess access)
 {
     switch (access)
@@ -87,6 +102,7 @@ bool QueryRuntimeMemory(const void* pointer, size_t minBytes, RuntimeMemoryQuery
     const auto value = reinterpret_cast<std::uintptr_t>(pointer);
     outQuery = {};
     outQuery.value = value;
+    g_virtualQueryCalls.fetch_add(1, std::memory_order_relaxed);
 
     if (value < 0x10000 || value == ~std::uintptr_t{ 0 })
     {
@@ -221,6 +237,7 @@ bool TryRunGuardedCallbackRaw(RuntimeGuardCallback callback, void* context, SehC
     if (!callback)
         return false;
 
+    const uint64_t startNs = GuardTelemetryNowNs();
     ++g_guardedCallbackDepth;
     bool result = false;
 #if defined(_MSC_VER) || defined(__clang__)
@@ -237,6 +254,7 @@ bool TryRunGuardedCallbackRaw(RuntimeGuardCallback callback, void* context, SehC
 #endif
 
     --g_guardedCallbackDepth;
+    g_guardedCallTotalNs.fetch_add(GuardTelemetryNowNs() - startNs, std::memory_order_relaxed);
     return result;
 }
 }
@@ -409,6 +427,14 @@ bool RuntimeCStringEquals(const char* pointer, const char* expected, size_t maxL
     }
 
     return false;
+}
+
+GuardTelemetryTotals GetGuardTelemetryTotals()
+{
+    GuardTelemetryTotals totals;
+    totals.guardedCallTotalNs = g_guardedCallTotalNs.load(std::memory_order_relaxed);
+    totals.virtualQueryCalls = g_virtualQueryCalls.load(std::memory_order_relaxed);
+    return totals;
 }
 
 RuntimeGuardSnapshot GetRuntimeGuardSnapshot()

--- a/CoopPrototype/Src/CoopRuntimeGuards.h
+++ b/CoopPrototype/Src/CoopRuntimeGuards.h
@@ -46,6 +46,16 @@ std::string GetRuntimeModulePath(const void* pointer);
 std::string ReadRuntimeCString(const char* pointer, size_t maxLength);
 bool RuntimeCStringEquals(const char* pointer, const char* expected, size_t maxLength);
 RuntimeGuardSnapshot GetRuntimeGuardSnapshot();
+
+// Self-profiling totals (lock-free): cumulative time inside guarded callbacks
+// (including VirtualQuery preflight reads) and the number of VirtualQuery
+// calls made by the guard layer. Windows-only cost centers — see RESULTS.md.
+struct GuardTelemetryTotals
+{
+    uint64_t guardedCallTotalNs = 0;
+    uint64_t virtualQueryCalls = 0;
+};
+GuardTelemetryTotals GetGuardTelemetryTotals();
 bool IsGuardedCallbackActive();
 
 using RuntimeGuardCallback = bool (*)(void* context);

--- a/CoopPrototype/Src/CoopRuntimeGuards.h
+++ b/CoopPrototype/Src/CoopRuntimeGuards.h
@@ -48,15 +48,73 @@ bool RuntimeCStringEquals(const char* pointer, const char* expected, size_t maxL
 RuntimeGuardSnapshot GetRuntimeGuardSnapshot();
 
 // Self-profiling totals (lock-free): cumulative time inside guarded callbacks
-// (including VirtualQuery preflight reads) and the number of VirtualQuery
-// calls made by the guard layer. Windows-only cost centers — see RESULTS.md.
+// (including VirtualQuery preflight reads) and the number of actual VirtualQuery
+// API calls made by the guard layer. Windows-only cost centers — see RESULTS.md.
 struct GuardTelemetryTotals
 {
     uint64_t guardedCallTotalNs = 0;
     uint64_t virtualQueryCalls = 0;
+    uint64_t sehExceptions = 0;
+    uint64_t guardedCallFailures = 0;
+    uint64_t preflightFailures = 0;
 };
 GuardTelemetryTotals GetGuardTelemetryTotals();
+
+// Top guarded operations by cumulative time: "name:calls:us|name:calls:us..."
+// (up to 5 entries; empty when nothing recorded). Window deltas are computed
+// by the caller between snapshots.
+std::string GetGuardOpReport();
+// Raw/untrusted-output read API. The destination is validated with VQ before
+// a guarded commit, but concurrent protection/lifetime changes can still make
+// that commit fail after writing some bytes; it is not atomic. Source reads
+// use direct SEH by default; COOP_RUNTIME_READ_MODE=vq restores the old
+// preflight path.
+bool TryReadRuntimeValueSeh(const void* pointer, void* outValue, size_t size);
+bool TryRuntimeReadProbeSeh(const void* pointer, size_t size);
+const char* RuntimeReadModeName();
+const char* RuntimeReadEffectiveModeName();
+const char* RuntimeObjectProbeModeName();
+const char* RuntimeObjectProbeEffectiveModeName();
+const char* RuntimeGuardPagePolicyName();
+
+struct RuntimeReadTelemetry
+{
+    uint64_t attempts = 0;
+    uint64_t failures = 0;
+    uint64_t accessViolationFailures = 0;
+    uint64_t inPageErrorFailures = 0;
+    uint64_t guardPageFailures = 0;
+    uint64_t otherFailures = 0;
+    // PAGE_GUARD re-arm counters; allowConsume intentionally reports zero.
+    uint64_t guardPageRestoreAttempts = 0;
+    uint64_t guardPageRestoreSuccesses = 0;
+    uint64_t guardPageRestoreFailures = 0;
+    uint64_t guardPageRestoreAlreadyPresent = 0;
+    uint32_t lastExceptionCode = 0;
+};
+RuntimeReadTelemetry GetRuntimeReadTelemetry();
+
+struct RuntimeObjectProbeTelemetry
+{
+    uint64_t attempts = 0;
+    uint64_t failures = 0;
+};
+RuntimeObjectProbeTelemetry GetRuntimeObjectProbeTelemetry();
+
+uint64_t GetGuardVqCalls();
+uint64_t GetGuardVqTotalNs();
+
+// Wall-clock nanoseconds for experiment instrumentation (steady_clock).
+uint64_t GuardTelemetryNowNsPublic();
 bool IsGuardedCallbackActive();
+
+namespace detail
+{
+// Trusted destination used only by the typed T& wrapper above. The caller
+// must provide a valid writable object; unlike the raw API this intentionally
+// does not probe the destination.
+bool TryReadRuntimeValueTrustedSeh(const void* pointer, void* outValue, size_t size);
+}
 
 using RuntimeGuardCallback = bool (*)(void* context);
 bool TryRunGuardedCallback(
@@ -68,10 +126,14 @@ bool TryRunGuardedCallback(
 template <typename T>
 bool TryReadRuntimeValue(const T* pointer, T& outValue)
 {
-    if (!PreflightRuntimePointer("read runtime value", pointer, sizeof(T), RuntimeAccess::Read))
+    // T& is a trusted, live destination owned by the caller. Read into a
+    // local value first so a source fault cannot modify the caller's output.
+    // The direct path writes only this local under SEH and commits after a
+    // complete read; the explicit VQ mode performs its source preflight.
+    T staged{};
+    if (!detail::TryReadRuntimeValueTrustedSeh(pointer, &staged, sizeof(T)))
         return false;
-
-    std::memcpy(&outValue, pointer, sizeof(T));
+    std::memcpy(&outValue, &staged, sizeof(T));
     return true;
 }
 

--- a/CoopPrototype/Src/ModMain.cpp
+++ b/CoopPrototype/Src/ModMain.cpp
@@ -1,5 +1,6 @@
 #include "ModMain.h"
 #include "CoopRuntimeGuards.h"
+#include "CoopHookStats.h"
 #include "CoopWorkstationSync.h"
 #include "CoopSerialSequence.h"
 #include "CoopRuntimeLog.h"
@@ -7218,6 +7219,17 @@ std::string ModMain::BuildRuntimeCostReport() const
         << ",boxHuge=" << m_physicalWorldBoxHookHugeQueries
         << ",mannequin=" << m_npcMannequinConstructTraceCount
         << ",semantic=" << m_npcSemanticTraceCount;
+
+    // Windows-only cost centers: guarded callbacks (SEH + VirtualQuery) and
+    // per-hook self-profiling. See the issue #2 investigation notes.
+    const CoopRuntimeGuards::GuardTelemetryTotals guardTotals =
+        CoopRuntimeGuards::GetGuardTelemetryTotals();
+    out << ",guardCallsNs=" << guardTotals.guardedCallTotalNs
+        << ",virtualQueries=" << guardTotals.virtualQueryCalls;
+
+    const std::string hookStats = CoopHookStats::BuildReport();
+    if (!hookStats.empty())
+        out << ",hookStats=" << hookStats;
     return out.str();
 }
 
@@ -16667,8 +16679,10 @@ static void ArkOperatorLaserHelper_DoDamage_Hook(
     s_hookArkOperatorLaserDamage.InvokeOrig(helper, npc, frameTime, collision);
 }
 
+static CoopHookStats::Slot* s_hookStatMannequinStoreAction = CoopHookStats::Register("Mannequin::StoreAction");
 static void ArkNpcBodyState_StoreAction_Hook(void* stateSlot, void* transitionPayload)
 {
+    CoopHookStats::Scoped hookStatScope(s_hookStatMannequinStoreAction);
     const std::string callChain = CaptureMannequinCallChainTrace("ArkNpcBodyState::StoreAction");
     if (gMod)
         gMod->RecordNpcMannequinStoreAction(
@@ -16685,6 +16699,7 @@ static void ArkNpcBodyState_StoreAction_Hook(void* stateSlot, void* transitionPa
             callChain.c_str());
 }
 
+static CoopHookStats::Slot* s_hookStatSetPosRotScale = CoopHookStats::Register("CEntity::SetPosRotScale");
 static void CEntity_SetPosRotScale_RemoteEnemyTransform_Hook(
     CEntity* entity,
     Vec3 const& position,
@@ -16692,6 +16707,7 @@ static void CEntity_SetPosRotScale_RemoteEnemyTransform_Hook(
     Vec3 const& scale,
     int whyFlags)
 {
+    CoopHookStats::Scoped hookStatScope(s_hookStatSetPosRotScale);
     TracePostLoadNativeHook("CEntity::SetPosRotScale");
     if (gMod)
         gMod->RecordRuntimeTransformHook(false);
@@ -16737,11 +16753,13 @@ static void CEntity_SetPosRotScale_RemoteEnemyTransform_Hook(
     invokeOrig(position, rotation);
 }
 
+static CoopHookStats::Slot* s_hookStatSetWorldTM = CoopHookStats::Register("CEntity::SetWorldTM");
 static void CEntity_SetWorldTM_RemoteEnemyTransform_Hook(
     CEntity* entity,
     Matrix34 const& tm,
     int whyFlags)
 {
+    CoopHookStats::Scoped hookStatScope(s_hookStatSetWorldTM);
     TracePostLoadNativeHook("CEntity::SetWorldTM");
     if (gMod)
         gMod->RecordRuntimeTransformHook(false);
@@ -16798,6 +16816,7 @@ static void CEntity_SetWorldTM_RemoteEnemyTransform_Hook(
     invokeOrig(tm);
 }
 
+static CoopHookStats::Slot* s_hookStatSetPos = CoopHookStats::Register("CEntity::SetPos");
 static void CEntity_SetPos_RemoteEnemyTransform_Hook(
     CEntity* entity,
     Vec3 const& position,
@@ -16805,6 +16824,7 @@ static void CEntity_SetPos_RemoteEnemyTransform_Hook(
     bool recalcPhysicsBounds,
     bool force)
 {
+    CoopHookStats::Scoped hookStatScope(s_hookStatSetPos);
     TracePostLoadNativeHook("CEntity::SetPos");
     if (gMod)
         gMod->RecordRuntimeTransformHook(false);
@@ -16850,11 +16870,13 @@ static void CEntity_SetPos_RemoteEnemyTransform_Hook(
     invokeOrig(position);
 }
 
+static CoopHookStats::Slot* s_hookStatSetRotation = CoopHookStats::Register("CEntity::SetRotation");
 static void CEntity_SetRotation_RemoteEnemyTransform_Hook(
     CEntity* entity,
     Quat const& rotation,
     int whyFlags)
 {
+    CoopHookStats::Scoped hookStatScope(s_hookStatSetRotation);
     TracePostLoadNativeHook("CEntity::SetRotation");
     if (gMod)
         gMod->RecordRuntimeTransformHook(false);
@@ -20996,6 +21018,7 @@ static bool ArkKeycardReader_SetLocked_Hook(ArkKeycardReader* reader, bool locke
     return result;
 }
 
+static CoopHookStats::Slot* s_hookStatSignalSendPackage = CoopHookStats::Register("Signal::SendPackage");
 static void ArkSignalManager_SendPackage_Hook(
     ArkSignalSystem::Manager* manager,
     unsigned targetEntityId,
@@ -21008,6 +21031,7 @@ static void ArkSignalManager_SendPackage_Hook(
     float repeatTime,
     bool delayFirstSend)
 {
+    CoopHookStats::Scoped hookStatScope(s_hookStatSignalSendPackage);
     if (gMod && manager)
     {
         gMod->OnArkEnemySignalPackageObserved(
@@ -21072,11 +21096,13 @@ static void ArkSignalManager_SendPackage_Hook(
         delayFirstSend);
 }
 
+static CoopHookStats::Slot* s_hookStatSignalSendToReceiver = CoopHookStats::Register("Signal::SendToReceiver");
 static void ArkSignalManager_SendToReceiver_Hook(
     ArkSignalSystem::Manager* manager,
     const unsigned targetEntityId,
     const ArkSignalSystem::Package& package)
 {
+    CoopHookStats::Scoped hookStatScope(s_hookStatSignalSendToReceiver);
     bool suppressEnemyReceiver = false;
     if (gMod && manager)
     {
@@ -34834,6 +34860,34 @@ void ModMain::OnArkSaveLoadSerializePersistentStateHook(
 void ModMain::MainUpdate(unsigned updateFlags)
 {
     const float frameTime = gEnv && gEnv->pTimer ? gEnv->pTimer->GetFrameTime() : 0.0f;
+
+    // Periodic self-profiling dump (issue #2): hook cost breakdown + guarded
+    // call / VirtualQuery totals straight into Game.log, independent of the
+    // extractor status writer. Once per ~10 s at 60 fps (600 frames).
+    {
+        static std::atomic<uint32_t> s_hookStatFrameCounter{0};
+        static std::atomic<uint64_t> s_lastDumpGuardNs{0};
+        static std::atomic<uint64_t> s_lastDumpVq{0};
+        if ((s_hookStatFrameCounter.fetch_add(1, std::memory_order_relaxed) % 600u) == 0u)
+        {
+            const CoopRuntimeGuards::GuardTelemetryTotals totals =
+                CoopRuntimeGuards::GetGuardTelemetryTotals();
+            const uint64_t guardDeltaNs =
+                totals.guardedCallTotalNs - s_lastDumpGuardNs.exchange(totals.guardedCallTotalNs);
+            const uint64_t vqDelta = totals.virtualQueryCalls - s_lastDumpVq.exchange(totals.virtualQueryCalls);
+            std::ostringstream out;
+            out << "hookstats windowFrames=600"
+                << " guardTotalNs=" << totals.guardedCallTotalNs
+                << " guardWindowNs=" << guardDeltaNs
+                << " virtualQueries=" << totals.virtualQueryCalls
+                << " vqWindow=" << vqDelta;
+            const std::string hooks = CoopHookStats::BuildReport();
+            if (!hooks.empty())
+                out << " hooks=" << hooks;
+            CoopRuntimeLog::Write(out.str());
+            CoopHookStats::ResetAll();
+        }
+    }
     using XInputGetStateFn = DWORD(WINAPI*)(DWORD, XINPUT_STATE*);
     static XInputGetStateFn getXInputState = []() -> XInputGetStateFn
     {


### PR DESCRIPTION
## Problem

Successful `TryReadRuntimeValue` calls performed a `VirtualQuery` preflight before reading. This path runs at very high frequency during gameplay and caused the reported Windows-only frame-time collapse.

## Related issues
#2 

## Fix

- Read typed runtime values directly under Windows SEH by default.
- Preserve the caller's output when a source read faults.
- Catch access-violation, in-page, and guard-page faults.
- Re-arm `PAGE_GUARD` only on the exceptional path.
- Retain the old VQ-backed mode through `COOP_RUNTIME_READ_MODE=vq` for controlled diagnostics.
- Keep object probing independently VQ-backed by default.
- Scope `/EHa` and the PCH exclusion to `CoopRuntimeGuards.cpp` only.

The existing offline signal early-out and timing telemetry remain useful, but the guarded-read preflight was the measured performance fix.

## Verification

- Public `perf/hook-stats` branch built successfully as a Release DLL.
- Tested DLL SHA-256: `6f1f98289918bed689eaee6569ffa21b9f309515d0fd93cb8f0149786902dcf2`.
- The exact same DLL was loaded on the native Windows host and Linux/Proton client.
- Windows host remained responsive and listened on UDP 27015.
- Linux joined successfully; both peers reported `remotePeerCount=1`, `sessionReady=1`, `connected_same_level`, and `campaign/research/prototype`.
- No `error.log` was produced on either side, and the user confirmed the Windows performance regression is gone.
- The byte-identical guard implementation previously passed the five native Windows fault/policy configurations with zero failures, including hardware AV, no-access, cross-page, unchanged-output, and PAGE_GUARD restoration cases.

Other load/shutdown and gameplay issues are intentionally outside this PR.