### PR TITLE
Fix Unicode Windows profile paths

### DIFF
--- a/CoopPrototype/Src/CMakeLists.txt
+++ b/CoopPrototype/Src/CMakeLists.txt
@@ -90,6 +90,7 @@ set(SOURCE_FILES
 	CoopRuntimeLog.h
 	CoopRuntimeConfig.cpp
 	CoopRuntimeConfig.h
+	CoopFilesystem.h
 	CoopSerializerTrace.h
 	CoopSaveStoreDecoder.cpp
 	CoopSaveStoreDecoder.h

--- a/CoopPrototype/Src/CoopAnimationTest.cpp
+++ b/CoopPrototype/Src/CoopAnimationTest.cpp
@@ -1,4 +1,5 @@
 #include "ModMain.h"
+#include "CoopFilesystem.h"
 #include "CoopRuntimeConfig.h"
 #include "CoopRuntimeGuards.h"
 #include "CoopRuntimeLog.h"
@@ -1528,11 +1529,10 @@ std::string BuildProxyAnimationStateCatalog(const std::string& filter)
 
 std::filesystem::path GetCoopAnimationCatalogRoot()
 {
-    const char* userProfile = std::getenv("USERPROFILE");
-    if (!userProfile || !userProfile[0])
+    std::filesystem::path root = CoopFilesystem::EnvironmentPath("USERPROFILE");
+    if (root.empty())
         return std::filesystem::path("CoopPrototype") / "AnimCatalog";
 
-    std::filesystem::path root(userProfile);
     root /= "Saved Games";
     root /= "Arkane Studios";
     root /= "Prey";
@@ -1581,7 +1581,7 @@ bool WriteMannequinSnippetCatalog(const std::string& kind, std::string& detail)
         std::ofstream file(outputPath, std::ios::binary | std::ios::trunc);
         if (!file)
         {
-            detail = "anim_snippet_catalog_failed reason=open_failed path=" + outputPath.string();
+            detail = "anim_snippet_catalog_failed reason=open_failed path=" + CoopFilesystem::ToUtf8(outputPath);
             return false;
         }
 
@@ -1620,7 +1620,7 @@ bool WriteMannequinSnippetCatalog(const std::string& kind, std::string& detail)
             "anim_snippet_catalog_ok table=" + tableName +
             " fragments=" + std::to_string(fragmentCount) +
             " variants=" + std::to_string(variantCount) +
-            " path=" + outputPath.string();
+            " path=" + CoopFilesystem::ToUtf8(outputPath);
         return true;
     }
 

--- a/CoopPrototype/Src/CoopAssetDump.cpp
+++ b/CoopPrototype/Src/CoopAssetDump.cpp
@@ -1,4 +1,5 @@
 #include "ModMain.h"
+#include "CoopFilesystem.h"
 #include "CoopRuntimeLog.h"
 
 #include <algorithm>
@@ -81,11 +82,10 @@ void LogAssetDump(const std::string& message)
 
 std::filesystem::path GetCoopAssetDumpRoot()
 {
-    const char* userProfile = std::getenv("USERPROFILE");
-    if (!userProfile || !userProfile[0])
+    std::filesystem::path root = CoopFilesystem::EnvironmentPath("USERPROFILE");
+    if (root.empty())
         return std::filesystem::path("CoopPrototype") / "AssetDump";
 
-    std::filesystem::path root(userProfile);
     root /= "Saved Games";
     root /= "Arkane Studios";
     root /= "Prey";
@@ -266,7 +266,7 @@ bool TryWriteDecodedCryXml(const std::vector<char>& data, const std::filesystem:
     if (!parseResult)
     {
         CoopRuntimeLog::Write(
-            "asset_extract CryXml decode failed out=" + outputPath.string() +
+            "asset_extract CryXml decode failed out=" + CoopFilesystem::ToUtf8(outputPath) +
             " reason=" + parseResult.description());
         return false;
     }
@@ -484,7 +484,7 @@ bool ModMain::DebugCryPakAssetCommand(const std::string& command, const std::vec
         " bytes=" + std::to_string(copiedBytes) +
         " manifest=" + std::to_string(manifestOk ? 1 : 0) +
         " opened=" + openNote +
-        " out=" + outputRoot.string() +
+        " out=" + CoopFilesystem::ToUtf8(outputRoot) +
         " sample=" + FirstAssetSample(entries);
     LogAssetDump(detail);
     return copiedFiles > 0 && copiedFiles == entries.size() && manifestOk;

--- a/CoopPrototype/Src/CoopFilesystem.h
+++ b/CoopPrototype/Src/CoopFilesystem.h
@@ -1,0 +1,145 @@
+#pragma once
+
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include <string_view>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#ifdef min
+#undef min
+#endif
+#ifdef max
+#undef max
+#endif
+#endif
+
+// The CRT narrow environment and filesystem conversions use the active code
+// page on Windows. That loses usernames which cannot be represented by it.
+// Keep paths native while constructing them, and use UTF-8 only when a path
+// has to cross an existing std::string/game API boundary.
+namespace CoopFilesystem
+{
+inline std::wstring Utf8ToWide(std::string_view value)
+{
+#ifdef _WIN32
+    if (value.empty())
+        return {};
+
+    const int inputLength = static_cast<int>(value.size());
+    int required = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, value.data(), inputLength, nullptr, 0);
+    UINT codePage = CP_UTF8;
+    DWORD flags = MB_ERR_INVALID_CHARS;
+    if (required <= 0)
+    {
+        // Paths received from the game may still be encoded with the active
+        // Windows code page. Accept that legacy boundary while all generated
+        // paths use UTF-8 below.
+        codePage = CP_ACP;
+        flags = 0;
+        required = MultiByteToWideChar(codePage, flags, value.data(), inputLength, nullptr, 0);
+    }
+    if (required <= 0)
+        return {};
+
+    std::wstring result(static_cast<size_t>(required), L'\0');
+    if (MultiByteToWideChar(codePage, flags, value.data(), inputLength, result.data(), required) <= 0)
+        return {};
+    return result;
+#else
+    return std::wstring(value.begin(), value.end());
+#endif
+}
+
+inline std::string WideToUtf8(std::wstring_view value)
+{
+#ifdef _WIN32
+    if (value.empty())
+        return {};
+
+    const int inputLength = static_cast<int>(value.size());
+    const int required = WideCharToMultiByte(
+        CP_UTF8,
+        WC_ERR_INVALID_CHARS,
+        value.data(),
+        inputLength,
+        nullptr,
+        0,
+        nullptr,
+        nullptr);
+    if (required <= 0)
+        return {};
+
+    std::string result(static_cast<size_t>(required), '\0');
+    if (WideCharToMultiByte(
+            CP_UTF8,
+            WC_ERR_INVALID_CHARS,
+            value.data(),
+            inputLength,
+            result.data(),
+            required,
+            nullptr,
+            nullptr) <= 0)
+    {
+        return {};
+    }
+    return result;
+#else
+    return std::string(value.begin(), value.end());
+#endif
+}
+
+inline std::filesystem::path FromUtf8(std::string_view value)
+{
+#ifdef _WIN32
+    return std::filesystem::path(Utf8ToWide(value));
+#else
+    return std::filesystem::path(std::string(value));
+#endif
+}
+
+inline std::string ToUtf8(const std::filesystem::path& value)
+{
+#ifdef _WIN32
+    return WideToUtf8(value.native());
+#else
+    return value.string();
+#endif
+}
+
+inline std::filesystem::path EnvironmentPath(const char* name)
+{
+    if (!name || !name[0])
+        return {};
+
+#ifdef _WIN32
+    std::wstring wideName;
+    for (const unsigned char* cursor = reinterpret_cast<const unsigned char*>(name); *cursor; ++cursor)
+        wideName.push_back(static_cast<wchar_t>(*cursor));
+
+    DWORD capacity = 256;
+    for (;;)
+    {
+        std::wstring value(static_cast<size_t>(capacity), L'\0');
+        const DWORD length = GetEnvironmentVariableW(wideName.c_str(), value.data(), capacity);
+        if (length == 0)
+            break;
+        // A successful query returns the character count excluding the null
+        // terminator; a truncated query returns the required size instead.
+        if (length < capacity)
+        {
+            value.resize(length);
+            return std::filesystem::path(value);
+        }
+        capacity = length + 1;
+    }
+#endif
+
+    const char* value = std::getenv(name);
+    return value && value[0] ? FromUtf8(value) : std::filesystem::path();
+}
+}

--- a/CoopPrototype/Src/CoopIdentityConfig.cpp
+++ b/CoopPrototype/Src/CoopIdentityConfig.cpp
@@ -183,7 +183,13 @@ bool CoopIdentityConfig::ValidateAndNormalize(std::string& reason)
 bool CoopIdentityConfig::LoadExisting()
 {
     pugi::xml_document document;
-    const pugi::xml_parse_result parsed = document.load_file(m_path.string().c_str(), pugi::parse_default, pugi::encoding_utf8);
+    std::ifstream input(m_path, std::ios::binary);
+    if (!input)
+    {
+        m_status = "parse failed: open";
+        return false;
+    }
+    const pugi::xml_parse_result parsed = document.load(input, pugi::parse_default, pugi::encoding_utf8);
     if (!parsed)
     {
         m_status = std::string("parse failed: ") + parsed.description();
@@ -283,7 +289,8 @@ bool CoopIdentityConfig::CreateNew(const std::string& fallbackUsername, const ch
 bool CoopIdentityConfig::RecoverCorrupt(const std::string& fallbackUsername, const char* reason)
 {
     std::error_code error;
-    const std::filesystem::path backup = m_path.string() + ".corrupt";
+    std::filesystem::path backup = m_path;
+    backup += ".corrupt";
     std::filesystem::remove(backup, error);
     error.clear();
     std::filesystem::rename(m_path, backup, error);
@@ -380,9 +387,17 @@ bool CoopIdentityConfig::Save()
     saveBookmarks(root.append_child("Favorites"), m_data.favoriteServers);
     saveBookmarks(root.append_child("RecentServers"), m_data.recentServers);
 
-    const std::filesystem::path tempPath = m_path.string() + ".tmp";
-    if (!document.save_file(tempPath.string().c_str(), "  ", pugi::format_default, pugi::encoding_utf8) ||
-        !ReplaceFile(tempPath, m_path))
+    std::filesystem::path tempPath = m_path;
+    tempPath += ".tmp";
+    std::ofstream output(tempPath, std::ios::binary | std::ios::trunc);
+    if (!output)
+    {
+        m_status = "save failed: write";
+        return false;
+    }
+    document.save(output, "  ", pugi::format_default, pugi::encoding_utf8);
+    output.close();
+    if (!output || !ReplaceFile(tempPath, m_path))
     {
         m_status = "save failed: write";
         return false;
@@ -451,7 +466,12 @@ bool CoopIdentityConfig::RunSelfTest(const std::filesystem::path& root, std::str
     CoopIdentityConfig recovered;
     if (!recovered.LoadOrCreate(root, "RecoveredPlayer") ||
         recovered.AccountToken() == 0 ||
-        !std::filesystem::exists(recovered.Path().string() + ".corrupt"))
+        !std::filesystem::exists([&]
+        {
+            std::filesystem::path backup = recovered.Path();
+            backup += ".corrupt";
+            return backup;
+        }()))
     {
         detail = "corruption_recovery_failed_" + recovered.Status();
         return false;

--- a/CoopPrototype/Src/CoopNativeFragmentPayload.cpp
+++ b/CoopPrototype/Src/CoopNativeFragmentPayload.cpp
@@ -1,5 +1,6 @@
 #include "CoopNativeFragmentPayload.h"
 
+#include "CoopFilesystem.h"
 #include "CoopNativeSaveStoreApi.h"
 #include "CoopRuntimeGuards.h"
 
@@ -998,7 +999,8 @@ bool WritePayloadFile(const std::filesystem::path& path, const BuildResult& resu
         return false;
     }
 
-    const std::filesystem::path tempPath = path.string() + ".tmp";
+    std::filesystem::path tempPath = path;
+    tempPath += ".tmp";
     std::ofstream output(tempPath, std::ios::binary | std::ios::trunc);
     if (!output)
     {

--- a/CoopPrototype/Src/CoopNativeSavePackageRewriter.cpp
+++ b/CoopPrototype/Src/CoopNativeSavePackageRewriter.cpp
@@ -1,5 +1,7 @@
 #include "CoopNativeSavePackageRewriter.h"
 
+#include "CoopFilesystem.h"
+
 #include <array>
 #include <fstream>
 #include <iomanip>
@@ -292,7 +294,7 @@ bool WriteRewritePlanMeta(
 
     meta << "version=1\n";
     meta << "mode=native_gamestate_section_rewriter_plan\n";
-    meta << "packageSave=" << input.packageSavePath.string() << "\n";
+    meta << "packageSave=" << CoopFilesystem::ToUtf8(input.packageSavePath) << "\n";
     meta << "attempted=" << (plan.attempted ? 1 : 0) << "\n";
     meta << "ok=" << (plan.ok ? 1 : 0) << "\n";
     meta << "reason=" << plan.reason << "\n";

--- a/CoopPrototype/Src/CoopPlayerSidecar.cpp
+++ b/CoopPrototype/Src/CoopPlayerSidecar.cpp
@@ -1,5 +1,6 @@
 #include "ModMain.h"
 #include "CoopRuntimeConfig.h"
+#include "CoopFilesystem.h"
 #include "CoopRuntimeLog.h"
 #include "CoopItemClassification.h"
 #include "CoopPtrHygiene.h"
@@ -223,7 +224,7 @@ bool ReadAndValidatePlayerSidecarFile(
     outHasIntegrityHash = false;
     outReason.clear();
 
-    std::ifstream input(pathString, std::ios::binary);
+    std::ifstream input(CoopFilesystem::FromUtf8(pathString), std::ios::binary);
     if (!input)
     {
         outReason = "open failed";
@@ -304,7 +305,8 @@ bool ReadAndValidatePlayerSidecarFile(
 
 bool WritePlayerSidecarPayloadWithHash(const std::filesystem::path& path, const std::string& payload)
 {
-    const std::filesystem::path tempPath = path.string() + ".tmp";
+    std::filesystem::path tempPath = path;
+    tempPath += ".tmp";
     std::ofstream output(tempPath, std::ios::binary | std::ios::trunc);
     if (!output)
         return false;
@@ -341,11 +343,10 @@ bool ShouldApplyPlayerSidecarViewRotation(const ArkPlayer& player, const Quat& r
 
 std::filesystem::path GetPreyProfileRoot()
 {
-    const char* userProfile = std::getenv("USERPROFILE");
-    if (!userProfile || !userProfile[0])
+    std::filesystem::path root = CoopFilesystem::EnvironmentPath("USERPROFILE");
+    if (root.empty())
         return {};
 
-    std::filesystem::path root(userProfile);
     root /= "Saved Games";
     root /= "Arkane Studios";
     root /= "Prey";
@@ -2518,7 +2519,7 @@ std::string ModMain::GetPlayerSidecarPath() const
         return {};
 
     const std::string fileName = "player_account_" + HexPlayerAccountToken(GetLocalAccountToken()) + ".state";
-    return (root / fileName).string();
+    return CoopFilesystem::ToUtf8(root / fileName);
 }
 
 bool ModMain::SaveLocalPlayerSidecar(const char* reason)
@@ -2554,7 +2555,7 @@ bool ModMain::SaveLocalPlayerSidecar(const char* reason)
         return false;
     }
 
-    const std::filesystem::path path(pathString);
+    const std::filesystem::path path = CoopFilesystem::FromUtf8(pathString);
     std::error_code error;
     std::filesystem::create_directories(path.parent_path(), error);
     if (error)
@@ -2863,15 +2864,15 @@ bool ModMain::LoadLocalPlayerSidecar(PlayerSidecarState& state)
         GetLegacyCoopPlayerStateRoot() / ("player_" + SanitizePathComponent(GetLocalUsername()) + ".state");
     for (const std::filesystem::path& candidate : { usernamePath, legacyPath })
     {
-        if (candidate.empty() || candidate.string() == pathString)
+        if (candidate.empty() || CoopFilesystem::ToUtf8(candidate) == pathString)
             continue;
-        if (!LoadPlayerSidecarFromPath(candidate.string(), state))
+        if (!LoadPlayerSidecarFromPath(CoopFilesystem::ToUtf8(candidate), state))
             continue;
 
         std::error_code error;
-        std::filesystem::create_directories(std::filesystem::path(pathString).parent_path(), error);
+        std::filesystem::create_directories(CoopFilesystem::FromUtf8(pathString).parent_path(), error);
         if (!error)
-            std::filesystem::copy_file(candidate, pathString, std::filesystem::copy_options::overwrite_existing, error);
+            std::filesystem::copy_file(candidate, CoopFilesystem::FromUtf8(pathString), std::filesystem::copy_options::overwrite_existing, error);
         m_lastPlayerSidecarEvent = error
             ? "loaded legacy player sidecar; account migration copy failed"
             : "loaded and migrated legacy player sidecar to account identity";

--- a/CoopPrototype/Src/CoopPreloadSaveMerge.cpp
+++ b/CoopPrototype/Src/CoopPreloadSaveMerge.cpp
@@ -1,5 +1,7 @@
 #include "CoopPreloadSaveMerge.h"
 
+#include "CoopFilesystem.h"
+
 #include <algorithm>
 #include <array>
 #include <fstream>
@@ -118,9 +120,9 @@ std::filesystem::path BuildMergedSlotPath(const std::filesystem::path& hostSaveP
     const std::filesystem::path mergeRoot = sourceRoot / "PreloadMerged";
 
     std::ostringstream name;
-    name << sourceSlot.filename().string() << "_merge_"
+    name << CoopFilesystem::ToUtf8(sourceSlot.filename()) << "_merge_"
          << std::hex << std::uppercase << std::setw(8) << std::setfill('0') << transferId;
-    return mergeRoot / name.str();
+    return mergeRoot / CoopFilesystem::FromUtf8(name.str());
 }
 
 bool CopySlotFiles(
@@ -156,7 +158,7 @@ bool CopySlotFiles(
         if (!entry.is_regular_file(fileError) || fileError)
             continue;
 
-        const std::string name = entry.path().filename().string();
+        const std::string name = CoopFilesystem::ToUtf8(entry.path().filename());
         if (!IsSafeSaveSlotFileName(name))
             continue;
 
@@ -172,7 +174,7 @@ bool CopySlotFiles(
 
         std::filesystem::copy_file(
             entry.path(),
-            targetSlot / name,
+            targetSlot / CoopFilesystem::FromUtf8(name),
             std::filesystem::copy_options::overwrite_existing,
             fileError);
         if (fileError)
@@ -264,10 +266,10 @@ bool WriteMergeMeta(
     meta << "mode=package_copy_pending_gamestate_rebuilder\n";
     meta << "patched=" << (result.patched ? 1 : 0) << "\n";
     meta << "transferId=" << input.transferId << "\n";
-    meta << "sourceSave=" << input.hostSavePath.string() << "\n";
+    meta << "sourceSave=" << CoopFilesystem::ToUtf8(input.hostSavePath) << "\n";
     meta << "hostSaveBytes=" << input.hostSaveBytes << "\n";
     meta << "hostSaveChecksum=" << Hex32(input.hostSaveChecksum) << "\n";
-    meta << "outputSave=" << result.mergedSavePath.string() << "\n";
+    meta << "outputSave=" << CoopFilesystem::ToUtf8(result.mergedSavePath) << "\n";
     meta << "outputSaveBytes=" << result.outputSaveBytes << "\n";
     meta << "outputSaveChecksum=" << Hex32(result.outputSaveChecksum) << "\n";
     meta << "nativeItems=" << input.nativeFragment.itemGroups << "\n";
@@ -275,7 +277,7 @@ bool WriteMergeMeta(
     meta << "nativeSchemaHash=" << Hex64(input.nativeFragment.schemaHash) << "\n";
     meta << "nativeContentHash=" << Hex64(input.nativeFragment.contentHash) << "\n";
     meta << "nativeSnapshotSave=" << (result.wroteNativeSnapshotSave ? 1 : 0) << "\n";
-    meta << "nativeSnapshotSavePath=" << result.nativeSnapshotSavePath.string() << "\n";
+    meta << "nativeSnapshotSavePath=" << CoopFilesystem::ToUtf8(result.nativeSnapshotSavePath) << "\n";
     meta << "nativeSnapshotSaveBytes=" << result.nativeSnapshotSaveBytes << "\n";
     meta << "nativeSnapshotSaveChecksum=" << Hex32(result.nativeSnapshotSaveChecksum) << "\n";
     meta << "nativeRewriteStatus=" << CoopNativeSavePackageRewriter::BuildStatus(result.rewritePlan) << "\n";
@@ -387,7 +389,7 @@ std::string BuildStatus(const MergeResult& result)
         << "/" << Hex32(result.nativeSnapshotSaveChecksum)
         << "/reason=" << StatusToken(result.reason)
         << "/rewrite=" << StatusToken(CoopNativeSavePackageRewriter::BuildStatus(result.rewritePlan))
-        << "/path=" << StatusToken(result.mergedSavePath.string());
+        << "/path=" << StatusToken(CoopFilesystem::ToUtf8(result.mergedSavePath));
     return out.str();
 }
 }

--- a/CoopPrototype/Src/CoopPtrHygiene.cpp
+++ b/CoopPrototype/Src/CoopPtrHygiene.cpp
@@ -1,6 +1,7 @@
 #include "CoopPtrHygiene.h"
 
 #include "CoopRuntimeConfig.h"
+#include "CoopFilesystem.h"
 #include "CoopRuntimeLog.h"
 
 #include <atomic>
@@ -34,11 +35,10 @@ bool EnvFlagValue()
 // ModMain internals.
 std::filesystem::path GetPreyProfileRoot()
 {
-    const char* userProfile = std::getenv("USERPROFILE");
-    if (!userProfile || !userProfile[0])
+    std::filesystem::path root = CoopFilesystem::EnvironmentPath("USERPROFILE");
+    if (root.empty())
         return {};
 
-    std::filesystem::path root(userProfile);
     root /= "Saved Games";
     root /= "Arkane Studios";
     root /= "Prey";

--- a/CoopPrototype/Src/CoopRuntimeExtractor.cpp
+++ b/CoopPrototype/Src/CoopRuntimeExtractor.cpp
@@ -1,6 +1,7 @@
 #include "CoopRuntimeExtractor.h"
 
 #include "CoopRuntimeConfig.h"
+#include "CoopFilesystem.h"
 #include "CoopRuntimeLog.h"
 #include "CoopRuntimeGuards.h"
 
@@ -280,19 +281,19 @@ std::string CoopRuntimeExtractor::GetCurrentLevelName() const
 
 std::string CoopRuntimeExtractor::GetExtractorRootPath() const
 {
-    const char* overridePath = std::getenv("COOP_EXTRACTOR_ROOT");
-    if (overridePath && overridePath[0])
-        return overridePath;
+    const std::filesystem::path overridePath = CoopFilesystem::EnvironmentPath("COOP_EXTRACTOR_ROOT");
+    if (!overridePath.empty())
+        return CoopFilesystem::ToUtf8(overridePath);
 
-    const char* userProfile = std::getenv("USERPROFILE");
-    if (userProfile && userProfile[0])
+    const std::filesystem::path userProfile = CoopFilesystem::EnvironmentPath("USERPROFILE");
+    if (!userProfile.empty())
     {
-        std::filesystem::path root(userProfile);
+        std::filesystem::path root = userProfile;
         root /= "Saved Games";
         root /= "Arkane Studios";
         root /= "Prey";
         root /= "CoopRuntimeExtractor";
-        return root.string();
+        return CoopFilesystem::ToUtf8(root);
     }
 
     return "CoopRuntimeExtractor";
@@ -300,27 +301,27 @@ std::string CoopRuntimeExtractor::GetExtractorRootPath() const
 
 std::string CoopRuntimeExtractor::GetCommandFilePath() const
 {
-    const char* overridePath = std::getenv("COOP_EXTRACTOR_COMMAND_FILE");
-    if (overridePath && overridePath[0])
-        return overridePath;
+    const std::filesystem::path overridePath = CoopFilesystem::EnvironmentPath("COOP_EXTRACTOR_COMMAND_FILE");
+    if (!overridePath.empty())
+        return CoopFilesystem::ToUtf8(overridePath);
 
-    std::filesystem::path path(GetExtractorRootPath());
+    std::filesystem::path path = CoopFilesystem::FromUtf8(GetExtractorRootPath());
     path /= "command.txt";
-    return path.string();
+    return CoopFilesystem::ToUtf8(path);
 }
 
 std::string CoopRuntimeExtractor::GetStatusFilePath() const
 {
-    std::filesystem::path path(GetExtractorRootPath());
+    std::filesystem::path path = CoopFilesystem::FromUtf8(GetExtractorRootPath());
     path /= "status.txt";
-    return path.string();
+    return CoopFilesystem::ToUtf8(path);
 }
 
 std::string CoopRuntimeExtractor::GetLatestExportPath() const
 {
-    std::filesystem::path path(GetExtractorRootPath());
+    std::filesystem::path path = CoopFilesystem::FromUtf8(GetExtractorRootPath());
     path /= "latest.jsonl";
-    return path.string();
+    return CoopFilesystem::ToUtf8(path);
 }
 
 bool CoopRuntimeExtractor::CaptureEntityRow(IEntity& entity, EntityRow& outRow)
@@ -668,7 +669,7 @@ bool CoopRuntimeExtractor::ProbeExtensionAcrossSnapshot(const std::string& exten
 bool CoopRuntimeExtractor::ExportJsonl()
 {
     ++m_exportCount;
-    const std::filesystem::path exportPath(GetLatestExportPath());
+    const std::filesystem::path exportPath = CoopFilesystem::FromUtf8(GetLatestExportPath());
     std::error_code error;
     std::filesystem::create_directories(exportPath.parent_path(), error);
     if (error)
@@ -743,7 +744,7 @@ bool CoopRuntimeExtractor::ExportJsonl()
             << "}\n";
     }
 
-    m_lastExportPath = exportPath.string();
+    m_lastExportPath = CoopFilesystem::ToUtf8(exportPath);
     m_lastStatus = "export OK " + m_lastExportPath;
     WriteStatusFile();
     LogExtractor(m_lastStatus);
@@ -757,7 +758,7 @@ void CoopRuntimeExtractor::ProcessCommandFile(float frameTime, bool controlOnly)
         return;
     m_commandPollAccumulator = 0.0f;
 
-    const std::filesystem::path commandPath(GetCommandFilePath());
+    const std::filesystem::path commandPath = CoopFilesystem::FromUtf8(GetCommandFilePath());
     std::error_code error;
     if (!std::filesystem::is_regular_file(commandPath, error) || error)
         return;
@@ -861,7 +862,7 @@ void CoopRuntimeExtractor::ProcessCommandText(const std::string& text, bool cont
 
 void CoopRuntimeExtractor::WriteStatusFile() const
 {
-    const std::filesystem::path statusPath(GetStatusFilePath());
+    const std::filesystem::path statusPath = CoopFilesystem::FromUtf8(GetStatusFilePath());
     std::error_code error;
     std::filesystem::create_directories(statusPath.parent_path(), error);
     if (error)

--- a/CoopPrototype/Src/CoopSaveStateBridge.cpp
+++ b/CoopPrototype/Src/CoopSaveStateBridge.cpp
@@ -2,6 +2,7 @@
 
 #include "CoopNativeFragmentPayload.h"
 #include "CoopNativeSideBlob.h"
+#include "CoopFilesystem.h"
 #include "CoopRuntimeGuards.h"
 
 #include <algorithm>
@@ -116,12 +117,14 @@ std::string PointerJson(const void* ptr)
 
 std::filesystem::path GetAtlasRootFromEnvironment()
 {
-    if (const char* overrideRoot = std::getenv("COOP_SAVE_ATLAS_ROOT"); overrideRoot && overrideRoot[0])
-        return std::filesystem::path(overrideRoot);
+    const std::filesystem::path overrideRoot = CoopFilesystem::EnvironmentPath("COOP_SAVE_ATLAS_ROOT");
+    if (!overrideRoot.empty())
+        return overrideRoot;
 
-    if (const char* userProfile = std::getenv("USERPROFILE"); userProfile && userProfile[0])
+    const std::filesystem::path userProfile = CoopFilesystem::EnvironmentPath("USERPROFILE");
+    if (!userProfile.empty())
     {
-        std::filesystem::path root(userProfile);
+        std::filesystem::path root = userProfile;
         root /= "Saved Games";
         root /= "Arkane Studios";
         root /= "Prey";
@@ -547,7 +550,7 @@ void CoopSaveStateBridge::EnsureAtlasRun()
     m_atlasRunStarted = true;
     m_atlasRunId = MakeAtlasRunId();
     const std::filesystem::path runRoot = GetAtlasRootFromEnvironment() / m_atlasRunId;
-    m_atlasRootPath = runRoot.string();
+    m_atlasRootPath = CoopFilesystem::ToUtf8(runRoot);
 
     std::error_code error;
     std::filesystem::create_directories(runRoot / "roots", error);
@@ -599,7 +602,7 @@ void CoopSaveStateBridge::WriteAtlasEvent(
     ++m_atlasEvents;
     m_lastAtlasEvent = std::string(kind && kind[0] ? kind : "event") + "_" + PhaseName(phase);
 
-    const std::filesystem::path runRoot(m_atlasRootPath);
+    const std::filesystem::path runRoot = CoopFilesystem::FromUtf8(m_atlasRootPath);
     std::ofstream out(runRoot / "calltree.jsonl", std::ios::binary | std::ios::app);
     if (!out)
         return;
@@ -632,7 +635,7 @@ void CoopSaveStateBridge::WriteAtlasSectionEvent(const SectionEvent& event)
     if (!m_atlasRunStarted)
         return;
 
-    const std::filesystem::path runRoot(m_atlasRootPath);
+    const std::filesystem::path runRoot = CoopFilesystem::FromUtf8(m_atlasRootPath);
     std::ofstream out(runRoot / "sections.jsonl", std::ios::binary | std::ios::app);
     if (!out)
         return;
@@ -659,7 +662,7 @@ void CoopSaveStateBridge::WriteAtlasSummary()
     if (!m_atlasRunStarted)
         return;
 
-    const std::filesystem::path runRoot(m_atlasRootPath);
+    const std::filesystem::path runRoot = CoopFilesystem::FromUtf8(m_atlasRootPath);
     std::ofstream out(runRoot / "schema_summary.txt", std::ios::binary | std::ios::trunc);
     if (!out)
         return;
@@ -809,7 +812,7 @@ void CoopSaveStateBridge::RecordSerializerStoreProbe(
     const uint64_t parent = g_saveTraceStack.empty() ? 0 : g_saveTraceStack.back();
     const std::string section = FindSectionForSerializerImpl(serializerPtr);
 
-    const std::filesystem::path runRoot(m_atlasRootPath);
+    const std::filesystem::path runRoot = CoopFilesystem::FromUtf8(m_atlasRootPath);
     std::ofstream out(runRoot / "store_probes.jsonl", std::ios::binary | std::ios::app);
     if (!out)
         return;

--- a/CoopPrototype/Src/ModMain.cpp
+++ b/CoopPrototype/Src/ModMain.cpp
@@ -5,6 +5,7 @@
 #include "CoopSerialSequence.h"
 #include "CoopRuntimeLog.h"
 #include "CoopRuntimeConfig.h"
+#include "CoopFilesystem.h"
 #include "CoopPtrHygiene.h"
 #include "CoopDamagePolicy.h"
 #include "CoopCampaignAreaFacts.generated.h"
@@ -3285,7 +3286,7 @@ uint32_t UpdateFnv1a(uint32_t checksum, const uint8_t* data, size_t size)
 
 bool GetFileSizeBytes(const std::string& path, uint32_t& outSize)
 {
-    std::ifstream stream(path, std::ios::binary | std::ios::ate);
+    std::ifstream stream(CoopFilesystem::FromUtf8(path), std::ios::binary | std::ios::ate);
     if (!stream)
         return false;
 
@@ -3299,7 +3300,7 @@ bool GetFileSizeBytes(const std::string& path, uint32_t& outSize)
 
 bool ComputeFileChecksum(const std::string& path, uint32_t& outChecksum)
 {
-    std::ifstream stream(path, std::ios::binary);
+    std::ifstream stream(CoopFilesystem::FromUtf8(path), std::ios::binary);
     if (!stream)
         return false;
 
@@ -3343,7 +3344,7 @@ bool ReadBinaryFileLimited(
         return false;
 
     std::error_code error;
-    const std::filesystem::path fsPath(path);
+    const std::filesystem::path fsPath = CoopFilesystem::FromUtf8(path);
     if (!std::filesystem::is_regular_file(fsPath, error) || error)
         return false;
 
@@ -3493,7 +3494,8 @@ bool ValidatePlayerStateIntegrityFile(
 
 bool WriteTextFileWithIntegrityHash(const std::filesystem::path& path, const std::string& payload)
 {
-    const std::filesystem::path tempPath = path.string() + ".tmp";
+    std::filesystem::path tempPath = path;
+    tempPath += ".tmp";
     std::ofstream output(tempPath, std::ios::binary | std::ios::trunc);
     if (!output)
         return false;
@@ -3540,11 +3542,10 @@ bool ReadBinaryValue(std::istream& stream, T& value)
 
 std::filesystem::path GetPreyProfileRoot()
 {
-    const char* userProfile = std::getenv("USERPROFILE");
-    if (!userProfile || !userProfile[0])
+    std::filesystem::path root = CoopFilesystem::EnvironmentPath("USERPROFILE");
+    if (root.empty())
         return {};
 
-    std::filesystem::path root(userProfile);
     root /= "Saved Games";
     root /= "Arkane Studios";
     root /= "Prey";
@@ -3669,45 +3670,35 @@ std::string BuildCoopReceivedSavePath(uint32_t transferId)
         std::error_code error;
         std::filesystem::create_directories(slotPath, error);
         if (!error)
-            return (slotPath / "save.CSF").string();
+            return CoopFilesystem::ToUtf8(slotPath / "save.CSF");
     }
 
-    const char* tempRoot = std::getenv("TEMP");
-    if (!tempRoot || !tempRoot[0])
-        tempRoot = std::getenv("TMP");
+    std::filesystem::path tempRoot = CoopFilesystem::EnvironmentPath("TEMP");
+    if (tempRoot.empty())
+        tempRoot = CoopFilesystem::EnvironmentPath("TMP");
 
     char fileName[64] = {};
     std::snprintf(fileName, sizeof(fileName), "PreyCoopHostWorld_%08X.sav", transferId);
 
-    if (!tempRoot || !tempRoot[0])
+    if (tempRoot.empty())
         return std::string(fileName);
 
-    std::string path = tempRoot;
-    const char last = path.empty() ? '\0' : path.back();
-    if (last != '\\' && last != '/')
-        path += "\\";
-    path += fileName;
-    return path;
+    return CoopFilesystem::ToUtf8(tempRoot / fileName);
 }
 
 std::string BuildCoopReceivedSavePackagePath(uint32_t transferId)
 {
-    const char* tempRoot = std::getenv("TEMP");
-    if (!tempRoot || !tempRoot[0])
-        tempRoot = std::getenv("TMP");
+    std::filesystem::path tempRoot = CoopFilesystem::EnvironmentPath("TEMP");
+    if (tempRoot.empty())
+        tempRoot = CoopFilesystem::EnvironmentPath("TMP");
 
     char fileName[64] = {};
     std::snprintf(fileName, sizeof(fileName), "PreyCoopHostWorld_%08X.cspkg", transferId);
 
-    if (!tempRoot || !tempRoot[0])
+    if (tempRoot.empty())
         return std::string(fileName);
 
-    std::string path = tempRoot;
-    const char last = path.empty() ? '\0' : path.back();
-    if (last != '\\' && last != '/')
-        path += "\\";
-    path += fileName;
-    return path;
+    return CoopFilesystem::ToUtf8(tempRoot / fileName);
 }
 
 std::filesystem::path BuildCoopClientSaveQuarantineRoot()
@@ -5178,7 +5169,7 @@ bool TryReadableSaveCandidate(const std::filesystem::path& path, std::string& ou
     uint32_t ignoredSize = 0;
     if (IsReadableFile(path, &ignoredSize))
     {
-        outPath = NormalizeNativeWindowsPath(path.string());
+        outPath = NormalizeNativeWindowsPath(CoopFilesystem::ToUtf8(path));
         return true;
     }
 
@@ -5188,7 +5179,7 @@ bool TryReadableSaveCandidate(const std::filesystem::path& path, std::string& ou
         const std::filesystem::path saveCsf = path / "save.CSF";
         if (IsReadableFile(saveCsf, &ignoredSize))
         {
-            outPath = NormalizeNativeWindowsPath(saveCsf.string());
+            outPath = NormalizeNativeWindowsPath(CoopFilesystem::ToUtf8(saveCsf));
             return true;
         }
     }
@@ -5201,14 +5192,14 @@ bool ResolveReadableSaveFile(const std::string& savePathOrName, std::string& out
     if (savePathOrName.empty() || savePathOrName == "-")
         return false;
 
-    if (TryReadableSaveCandidate(std::filesystem::path(savePathOrName), outPath))
+    if (TryReadableSaveCandidate(CoopFilesystem::FromUtf8(savePathOrName), outPath))
         return true;
 
     const std::filesystem::path saveRoot = GetPreySaveGamesRoot();
     if (saveRoot.empty())
         return false;
 
-    if (TryReadableSaveCandidate(saveRoot / savePathOrName, outPath))
+    if (TryReadableSaveCandidate(saveRoot / CoopFilesystem::FromUtf8(savePathOrName), outPath))
         return true;
 
     // Save/load hooks commonly expose only a rotating slot name such as
@@ -5221,7 +5212,9 @@ bool ResolveReadableSaveFile(const std::string& savePathOrName, std::string& out
     {
         char campaignName[32] = {};
         std::snprintf(campaignName, sizeof(campaignName), "Campaign%d", campaignSlot);
-        if (TryReadableSaveCandidate(saveRoot / campaignName / savePathOrName, outPath))
+        if (TryReadableSaveCandidate(
+                saveRoot / CoopFilesystem::FromUtf8(campaignName) / CoopFilesystem::FromUtf8(savePathOrName),
+                outPath))
             return true;
     }
 
@@ -5236,7 +5229,7 @@ bool ResolveReadableSaveFile(const std::string& savePathOrName, std::string& out
         if (!campaignEntry.is_directory(error) || error)
             continue;
 
-        if (TryReadableSaveCandidate(campaignEntry.path() / savePathOrName, outPath))
+        if (TryReadableSaveCandidate(campaignEntry.path() / CoopFilesystem::FromUtf8(savePathOrName), outPath))
             return true;
     }
 
@@ -5249,7 +5242,7 @@ void RemoveResolvedSaveSlot(const std::string& savePathOrName, const char* reaso
     if (!ResolveReadableSaveFile(savePathOrName, resolvedPath))
         return;
 
-    std::filesystem::path path(resolvedPath);
+    const std::filesystem::path path = CoopFilesystem::FromUtf8(resolvedPath);
     std::filesystem::path slotDirectory = path.parent_path();
     if (slotDirectory.empty())
         return;
@@ -5261,7 +5254,7 @@ void RemoveResolvedSaveSlot(const std::string& savePathOrName, const char* reaso
         LogCoop(
             std::string("client snapshot cleanup failed") +
             (reason && reason[0] ? ": " + std::string(reason) : "") +
-            " path=" + slotDirectory.string() +
+            " path=" + CoopFilesystem::ToUtf8(slotDirectory) +
             " error=" + error.message());
         return;
     }
@@ -5269,7 +5262,7 @@ void RemoveResolvedSaveSlot(const std::string& savePathOrName, const char* reaso
     LogCoop(
         std::string("client snapshot cleanup removed") +
         (reason && reason[0] ? ": " + std::string(reason) : "") +
-        " path=" + slotDirectory.string());
+        " path=" + CoopFilesystem::ToUtf8(slotDirectory));
 }
 
 bool FindNewestSaveCsf(std::string& outPath)
@@ -5310,7 +5303,7 @@ bool FindNewestSaveCsf(std::string& outPath)
     if (newestPath.empty())
         return false;
 
-    outPath = NormalizeNativeWindowsPath(newestPath.string());
+    outPath = NormalizeNativeWindowsPath(CoopFilesystem::ToUtf8(newestPath));
     return true;
 }
 
@@ -5424,14 +5417,14 @@ bool CopyRegularFilesFlat(
     std::error_code error;
     if (!std::filesystem::is_directory(sourceDirectory, error) || error)
     {
-        summary.detail = "source missing: " + sourceDirectory.string();
+        summary.detail = "source missing: " + CoopFilesystem::ToUtf8(sourceDirectory);
         return false;
     }
 
     std::filesystem::create_directories(targetDirectory, error);
     if (error)
     {
-        summary.detail = "target mkdir failed: " + targetDirectory.string();
+        summary.detail = "target mkdir failed: " + CoopFilesystem::ToUtf8(targetDirectory);
         return false;
     }
 
@@ -5439,7 +5432,7 @@ bool CopyRegularFilesFlat(
     {
         if (error)
         {
-            summary.detail = "source iterate failed: " + sourceDirectory.string();
+            summary.detail = "source iterate failed: " + CoopFilesystem::ToUtf8(sourceDirectory);
             return false;
         }
 
@@ -5450,7 +5443,7 @@ bool CopyRegularFilesFlat(
             continue;
         }
 
-        const std::string name = entry.path().filename().string();
+        const std::string name = CoopFilesystem::ToUtf8(entry.path().filename());
         if (!IsSafeCoopSavePackageFileName(name) ||
             name == kCoopClientLevelStateBridgeMarker ||
             (skipSaveCsf && name == "save.CSF") ||
@@ -5469,7 +5462,7 @@ bool CopyRegularFilesFlat(
 
         std::filesystem::copy_file(
             entry.path(),
-            targetDirectory / name,
+            targetDirectory / CoopFilesystem::FromUtf8(name),
             std::filesystem::copy_options::overwrite_existing,
             fileError);
         if (fileError)
@@ -5527,7 +5520,7 @@ bool BuildCoopSavePackageFromSlot(const std::string& saveCsfPath, uint32_t trans
     outPackagePath.clear();
     outSummary.clear();
 
-    const std::filesystem::path savePath(saveCsfPath);
+    const std::filesystem::path savePath = CoopFilesystem::FromUtf8(saveCsfPath);
     const std::filesystem::path slotDir = savePath.parent_path();
     if (slotDir.empty())
     {
@@ -5551,7 +5544,7 @@ bool BuildCoopSavePackageFromSlot(const std::string& saveCsfPath, uint32_t trans
         if (!entry.is_regular_file(error) || error)
             continue;
 
-        const std::string name = entry.path().filename().string();
+        const std::string name = CoopFilesystem::ToUtf8(entry.path().filename());
         if (!IsSafeCoopSavePackageFileName(name))
             continue;
 
@@ -5560,7 +5553,7 @@ bool BuildCoopSavePackageFromSlot(const std::string& saveCsfPath, uint32_t trans
             continue;
 
         uint32_t checksum = 0;
-        if (!ComputeFileChecksum(entry.path().string(), checksum))
+        if (!ComputeFileChecksum(CoopFilesystem::ToUtf8(entry.path()), checksum))
             continue;
 
         totalBytes += static_cast<uint64_t>(fileSize);
@@ -5598,7 +5591,7 @@ bool BuildCoopSavePackageFromSlot(const std::string& saveCsfPath, uint32_t trans
     }
 
     const std::string packagePath = BuildCoopReceivedSavePackagePath(transferId);
-    std::ofstream package(packagePath, std::ios::binary | std::ios::trunc);
+    std::ofstream package(CoopFilesystem::FromUtf8(packagePath), std::ios::binary | std::ios::trunc);
     if (!package)
     {
         outSummary = "package open failed";
@@ -5672,7 +5665,7 @@ bool ExtractCoopSavePackageToSlot(const std::string& packagePath, uint32_t trans
     outSavePath.clear();
     outSummary.clear();
 
-    std::ifstream package(packagePath, std::ios::binary);
+    std::ifstream package(CoopFilesystem::FromUtf8(packagePath), std::ios::binary);
     if (!package)
     {
         outSummary = "package open failed";
@@ -5755,7 +5748,7 @@ bool ExtractCoopSavePackageToSlot(const std::string& packagePath, uint32_t trans
             return false;
         }
 
-        const std::filesystem::path outputPath = slotDir / name;
+        const std::filesystem::path outputPath = slotDir / CoopFilesystem::FromUtf8(name);
         std::ofstream output(outputPath, std::ios::binary | std::ios::trunc);
         if (!output)
         {
@@ -5804,7 +5797,7 @@ bool ExtractCoopSavePackageToSlot(const std::string& packagePath, uint32_t trans
         return false;
     }
 
-    outSavePath = savePath.string();
+    outSavePath = CoopFilesystem::ToUtf8(savePath);
     outSummary =
         "extracted native save slot entries=" + std::to_string(entryCount) +
         " bytes=" + std::to_string(totalBytes);
@@ -5813,44 +5806,34 @@ bool ExtractCoopSavePackageToSlot(const std::string& packagePath, uint32_t trans
 
 std::string BuildCoopTempPlayerStatePath(uint32_t transferId, const std::string& username)
 {
-    const char* tempRoot = std::getenv("TEMP");
-    if (!tempRoot || !tempRoot[0])
-        tempRoot = std::getenv("TMP");
+    std::filesystem::path tempRoot = CoopFilesystem::EnvironmentPath("TEMP");
+    if (tempRoot.empty())
+        tempRoot = CoopFilesystem::EnvironmentPath("TMP");
 
     char fileName[128] = {};
     const std::string safeUsername = SanitizePathComponent(username.empty() ? std::string("Player") : username);
     std::snprintf(fileName, sizeof(fileName), "PreyCoopPlayerState_%08X_%s.state", transferId, safeUsername.c_str());
 
-    if (!tempRoot || !tempRoot[0])
+    if (tempRoot.empty())
         return std::string(fileName);
 
-    std::string path = tempRoot;
-    const char last = path.empty() ? '\0' : path.back();
-    if (last != '\\' && last != '/')
-        path += "\\";
-    path += fileName;
-    return path;
+    return CoopFilesystem::ToUtf8(tempRoot / fileName);
 }
 
 std::string BuildCoopTempAreaJournalPath(uint32_t transferId, const std::string& levelName)
 {
-    const char* tempRoot = std::getenv("TEMP");
-    if (!tempRoot || !tempRoot[0])
-        tempRoot = std::getenv("TMP");
+    std::filesystem::path tempRoot = CoopFilesystem::EnvironmentPath("TEMP");
+    if (tempRoot.empty())
+        tempRoot = CoopFilesystem::EnvironmentPath("TMP");
 
     char fileName[192] = {};
     const std::string safeLevel = SanitizePathComponent(levelName.empty() ? std::string("unknown") : levelName);
     std::snprintf(fileName, sizeof(fileName), "PreyCoopAreaJournal_%08X_%s.jsonl", transferId, safeLevel.c_str());
 
-    if (!tempRoot || !tempRoot[0])
+    if (tempRoot.empty())
         return std::string(fileName);
 
-    std::string path = tempRoot;
-    const char last = path.empty() ? '\0' : path.back();
-    if (last != '\\' && last != '/')
-        path += "\\";
-    path += fileName;
-    return path;
+    return CoopFilesystem::ToUtf8(tempRoot / fileName);
 }
 
 std::string ToLowerAscii(std::string value)
@@ -26937,14 +26920,15 @@ void ModMain::FlushNativeFinalStreamCapture(const char* phase, bool result)
         partial +
         ".bin";
     const std::filesystem::path path = root / fileName;
-    const std::filesystem::path tempPath = path.string() + ".tmp";
+    std::filesystem::path tempPath = path;
+    tempPath += ".tmp";
 
     {
         std::ofstream output(tempPath, std::ios::binary | std::ios::trunc);
         if (!output)
         {
             ++m_nativeFinalStreamGuards;
-            m_lastNativeFinalStreamEvent = "final_stream dump_failed open path=" + StatusToken(path.string());
+            m_lastNativeFinalStreamEvent = "final_stream dump_failed open path=" + StatusToken(CoopFilesystem::ToUtf8(path));
             return;
         }
 
@@ -26954,7 +26938,7 @@ void ModMain::FlushNativeFinalStreamCapture(const char* phase, bool result)
         if (!output)
         {
             ++m_nativeFinalStreamGuards;
-            m_lastNativeFinalStreamEvent = "final_stream dump_failed write path=" + StatusToken(path.string());
+            m_lastNativeFinalStreamEvent = "final_stream dump_failed write path=" + StatusToken(CoopFilesystem::ToUtf8(path));
             return;
         }
     }
@@ -26971,12 +26955,13 @@ void ModMain::FlushNativeFinalStreamCapture(const char* phase, bool result)
             ++m_nativeFinalStreamGuards;
             m_lastNativeFinalStreamEvent =
                 "final_stream dump_failed commit " + StatusToken(error.message()) +
-                " path=" + StatusToken(path.string());
+                " path=" + StatusToken(CoopFilesystem::ToUtf8(path));
             return;
         }
     }
 
-    const std::filesystem::path metaPath = path.string() + ".txt";
+    std::filesystem::path metaPath = path;
+    metaPath += ".txt";
     std::ofstream meta(metaPath, std::ios::binary | std::ios::trunc);
     if (meta)
     {
@@ -27005,9 +26990,9 @@ void ModMain::FlushNativeFinalStreamCapture(const char* phase, bool result)
     }
 
     ++m_nativeFinalStreamDumpWrites;
-    m_lastNativeFinalStreamDumpPath = path.string();
+    m_lastNativeFinalStreamDumpPath = CoopFilesystem::ToUtf8(path);
     m_lastNativeFinalStreamEvent =
-        "final_stream dump_ok path=" + StatusToken(path.string()) +
+        "final_stream dump_ok path=" + StatusToken(CoopFilesystem::ToUtf8(path)) +
         " bytes=" + std::to_string(m_nativeFinalStreamBufferedBytes) +
         " dropped=" + std::to_string(m_nativeFinalStreamDroppedBytes) +
         " checksum=" + Hex32(m_nativeFinalStreamChecksum);
@@ -29201,7 +29186,7 @@ bool ModMain::WriteNativeSaveLoadXmlDiagnostics(const char* phase, const char* r
     if (!output)
     {
         ++m_nativePlayerXmlPatchFailures;
-        m_lastNativePlayerXmlPatchEvent = "xml diag failed: cannot open " + skeletonPath.string();
+        m_lastNativePlayerXmlPatchEvent = "xml diag failed: cannot open " + CoopFilesystem::ToUtf8(skeletonPath);
         return false;
     }
     output << skeleton.str();
@@ -29268,7 +29253,7 @@ bool ModMain::WriteNativeSaveLoadXmlDiagnostics(const char* phase, const char* r
 
     ++m_nativePlayerXmlDiagnosticsWrites;
     m_lastNativePlayerXmlPatchEvent =
-        "xml diag wrote " + skeletonPath.string() +
+        "xml diag wrote " + CoopFilesystem::ToUtf8(skeletonPath) +
         " nodes=" + std::to_string(visited) +
         " index=" + std::to_string(indexResult.written ? 1 : 0) +
         " indexNodes=" + std::to_string(indexResult.nodes) +
@@ -29647,7 +29632,7 @@ void ModMain::ActivateClientCoopSaveSlot(const std::string& savePath, uint32_t t
     if (m_networkMode != CoopNetworkMode::Client || savePath.empty())
         return;
 
-    const std::filesystem::path saveFile(savePath);
+    const std::filesystem::path saveFile = CoopFilesystem::FromUtf8(savePath);
     const std::filesystem::path slotDirectory = saveFile.parent_path();
     const std::filesystem::path tempDirectory = BuildCoopClientSessionTempDirectory();
     if (slotDirectory.empty() || tempDirectory.empty())
@@ -29658,8 +29643,8 @@ void ModMain::ActivateClientCoopSaveSlot(const std::string& savePath, uint32_t t
         return;
     }
 
-    m_activeClientCoopSaveSlotDirectory = slotDirectory.string();
-    m_activeClientCoopLevelStateDirectory = tempDirectory.string();
+    m_activeClientCoopSaveSlotDirectory = CoopFilesystem::ToUtf8(slotDirectory);
+    m_activeClientCoopLevelStateDirectory = CoopFilesystem::ToUtf8(tempDirectory);
     m_activeClientCoopSaveTransferId = transferId;
     m_clientCoopArkTempBridgeActive = false;
     m_clientCoopArkTempBridgeNeedsCleanup = false;
@@ -29683,8 +29668,8 @@ bool ModMain::SeedClientCoopLevelStateFromSaveSlot(const char* reason)
 
     CoopDirectoryCopySummary summary;
     if (!CopyRegularFilesFlat(
-            std::filesystem::path(m_activeClientCoopSaveSlotDirectory),
-            std::filesystem::path(m_activeClientCoopLevelStateDirectory),
+            CoopFilesystem::FromUtf8(m_activeClientCoopSaveSlotDirectory),
+            CoopFilesystem::FromUtf8(m_activeClientCoopLevelStateDirectory),
             true,
             false,
             summary))
@@ -29728,7 +29713,7 @@ bool ModMain::PrepareClientCoopLevelStateBridge(ArkSaveLoadSystem* saveLoadSyste
     if (m_networkMode != CoopNetworkMode::Client || m_activeClientCoopLevelStateDirectory.empty())
         return false;
 
-    const std::filesystem::path coopTempDirectory(m_activeClientCoopLevelStateDirectory);
+    const std::filesystem::path coopTempDirectory = CoopFilesystem::FromUtf8(m_activeClientCoopLevelStateDirectory);
     if (!DirectoryHasRegularFiles(coopTempDirectory) && !SeedClientCoopLevelStateFromSaveSlot(reason))
         return false;
 
@@ -29744,7 +29729,7 @@ bool ModMain::PrepareClientCoopLevelStateBridge(ArkSaveLoadSystem* saveLoadSyste
 
     if (m_clientCoopArkTempBridgeActive &&
         !m_clientCoopArkTempBridgePath.empty() &&
-        std::filesystem::path(m_clientCoopArkTempBridgePath) == arkTempDirectory &&
+        CoopFilesystem::FromUtf8(m_clientCoopArkTempBridgePath) == arkTempDirectory &&
         HasCoopClientLevelStateBridgeMarker(arkTempDirectory))
     {
         m_lastClientLevelStateBridgeEvent =
@@ -29775,7 +29760,7 @@ bool ModMain::PrepareClientCoopLevelStateBridge(ArkSaveLoadSystem* saveLoadSyste
     }
 
     ++m_clientLevelStateBridgeSyncs;
-    m_clientCoopArkTempBridgePath = arkTempDirectory.string();
+    m_clientCoopArkTempBridgePath = CoopFilesystem::ToUtf8(arkTempDirectory);
     m_clientCoopArkTempBridgeActive = true;
     m_clientCoopArkTempBridgeNeedsCleanup = true;
     m_lastClientLevelStateBridgeEvent =
@@ -29795,7 +29780,7 @@ bool ModMain::SyncClientCoopLevelStateBridgeFromArkTemp(const char* reason)
         return false;
     }
 
-    const std::filesystem::path arkTempDirectory(m_clientCoopArkTempBridgePath);
+    const std::filesystem::path arkTempDirectory = CoopFilesystem::FromUtf8(m_clientCoopArkTempBridgePath);
     if (!HasCoopClientLevelStateBridgeMarker(arkTempDirectory))
     {
         m_lastClientLevelStateBridgeEvent =
@@ -29807,7 +29792,7 @@ bool ModMain::SyncClientCoopLevelStateBridgeFromArkTemp(const char* reason)
     CoopDirectoryCopySummary summary;
     if (!CopyRegularFilesFlat(
             arkTempDirectory,
-            std::filesystem::path(m_activeClientCoopLevelStateDirectory),
+            CoopFilesystem::FromUtf8(m_activeClientCoopLevelStateDirectory),
             true,
             true,
             summary))
@@ -29833,7 +29818,7 @@ void ModMain::CleanupClientCoopLevelStateBridge(const char* reason)
     if (m_clientCoopArkTempBridgePath.empty())
         return;
 
-    const std::filesystem::path arkTempDirectory(m_clientCoopArkTempBridgePath);
+    const std::filesystem::path arkTempDirectory = CoopFilesystem::FromUtf8(m_clientCoopArkTempBridgePath);
     const bool marked = HasCoopClientLevelStateBridgeMarker(arkTempDirectory);
     if (marked && !SyncClientCoopLevelStateBridgeFromArkTemp(reason))
     {
@@ -30812,7 +30797,7 @@ void ModMain::InstallCrashExceptionHandler()
         std::error_code error;
         std::filesystem::create_directories(crashDir, error);
         if (!error)
-            g_crashTraceDirectory = crashDir.string();
+            g_crashTraceDirectory = CoopFilesystem::ToUtf8(crashDir);
     }
 
     if (!g_purecallTraceHandlerInstalled)
@@ -34123,10 +34108,10 @@ bool ModMain::TryExportNativeFragmentPayload(const char* reason)
     m_nativeFragmentPayloadExportBytes = static_cast<uint32_t>(payload.bytes.size());
     m_lastNativeFragmentPayloadSchemaHash = payload.schemaHash;
     m_lastNativeFragmentPayloadContentHash = payload.contentHash;
-    m_lastNativeFragmentPayloadPath = path.string();
+    m_lastNativeFragmentPayloadPath = CoopFilesystem::ToUtf8(path);
     m_lastNativeFragmentPayloadEvent =
         "payload exported " + CoopNativeFragmentPayload::BuildStatus(payload) +
-        " path=" + path.string() +
+        " path=" + CoopFilesystem::ToUtf8(path) +
         (reason && reason[0] ? " reason=" + std::string(reason) : "");
     LogCoop(m_lastNativeFragmentPayloadEvent);
     return true;
@@ -37797,7 +37782,7 @@ bool ModMain::DebugExportLocalInventoryJsonl(std::string& detail)
         return false;
     }
 
-    const std::filesystem::path exportPath(m_runtimeExtractor.GetLatestExportPath());
+    const std::filesystem::path exportPath = CoopFilesystem::FromUtf8(m_runtimeExtractor.GetLatestExportPath());
     std::error_code error;
     std::filesystem::create_directories(exportPath.parent_path(), error);
     if (error)
@@ -37950,7 +37935,7 @@ bool ModMain::DebugExportLocalInventoryJsonl(std::string& detail)
         ++exportedItems;
     }
 
-    detail = "inventory dump exported " + std::to_string(exportedItems) + " items to " + exportPath.string();
+    detail = "inventory dump exported " + std::to_string(exportedItems) + " items to " + CoopFilesystem::ToUtf8(exportPath);
     m_lastDebugInventoryEvent = detail;
     LogCoop(detail);
     return true;
@@ -37976,7 +37961,7 @@ bool ModMain::DebugExportLocalPlayerJsonl(std::string& detail)
         return false;
     }
 
-    const std::filesystem::path exportPath(m_runtimeExtractor.GetLatestExportPath());
+    const std::filesystem::path exportPath = CoopFilesystem::FromUtf8(m_runtimeExtractor.GetLatestExportPath());
     std::error_code error;
     std::filesystem::create_directories(exportPath.parent_path(), error);
     if (error)
@@ -38349,7 +38334,7 @@ bool ModMain::DebugExportLocalPlayerJsonl(std::string& detail)
             << "}\n";
     }
 
-    detail = "player dump exported to " + exportPath.string();
+    detail = "player dump exported to " + CoopFilesystem::ToUtf8(exportPath);
     m_lastDebugInventoryEvent = detail;
     LogCoop(detail);
     return true;
@@ -38377,7 +38362,7 @@ bool ModMain::DebugExportLocalEquipmentJsonl(std::string& detail)
         return false;
     }
 
-    const std::filesystem::path exportPath(m_runtimeExtractor.GetLatestExportPath());
+    const std::filesystem::path exportPath = CoopFilesystem::FromUtf8(m_runtimeExtractor.GetLatestExportPath());
     std::error_code error;
     std::filesystem::create_directories(exportPath.parent_path(), error);
     if (error)
@@ -38923,7 +38908,7 @@ bool ModMain::DebugExportLocalEquipmentJsonl(std::string& detail)
         }
     }
 
-    detail = "equipment dump exported " + std::to_string(exportedWeapons) + " weapons and " + std::to_string(exportedMods) + " mods to " + exportPath.string();
+    detail = "equipment dump exported " + std::to_string(exportedWeapons) + " weapons and " + std::to_string(exportedMods) + " mods to " + CoopFilesystem::ToUtf8(exportPath);
     m_lastDebugInventoryEvent = detail;
     LogCoop(detail);
     return true;
@@ -38933,7 +38918,7 @@ bool ModMain::DebugExportAreaJournalJsonl(std::string& detail)
 {
     detail.clear();
 
-    const std::filesystem::path exportPath(m_runtimeExtractor.GetLatestExportPath());
+    const std::filesystem::path exportPath = CoopFilesystem::FromUtf8(m_runtimeExtractor.GetLatestExportPath());
     std::error_code error;
     std::filesystem::create_directories(exportPath.parent_path(), error);
     if (error)
@@ -38960,7 +38945,7 @@ bool ModMain::DebugExportAreaJournalJsonl(std::string& detail)
         return false;
     }
 
-    detail = "area journal dump exported to " + exportPath.string();
+    detail = "area journal dump exported to " + CoopFilesystem::ToUtf8(exportPath);
     m_lastAreaAuthorityEvent = detail;
     LogCoop(detail);
     return true;
@@ -38977,7 +38962,7 @@ bool ModMain::DebugExportEnemyRegistryJsonl(std::string& detail)
         return false;
     }
 
-    const std::filesystem::path exportPath(m_runtimeExtractor.GetLatestExportPath());
+    const std::filesystem::path exportPath = CoopFilesystem::FromUtf8(m_runtimeExtractor.GetLatestExportPath());
     std::error_code error;
     std::filesystem::create_directories(exportPath.parent_path(), error);
     if (error)
@@ -39764,7 +39749,7 @@ bool ModMain::DebugExportEnemyRegistryJsonl(std::string& detail)
         " cullEligible=" + std::to_string(cullEligibleCount) +
         " auth=" + std::to_string(m_enemyAuthorities.size()) +
         " puppets=" + std::to_string(m_enemyPuppets.size()) +
-        " to " + exportPath.string();
+        " to " + CoopFilesystem::ToUtf8(exportPath);
     m_lastAreaAuthorityEvent = detail;
     LogCoop(detail);
     return true;
@@ -39781,7 +39766,7 @@ bool ModMain::DebugExportTurretRegistryJsonl(std::string& detail)
         return false;
     }
 
-    const std::filesystem::path exportPath(m_runtimeExtractor.GetLatestExportPath());
+    const std::filesystem::path exportPath = CoopFilesystem::FromUtf8(m_runtimeExtractor.GetLatestExportPath());
     std::error_code error;
     std::filesystem::create_directories(exportPath.parent_path(), error);
     if (error)
@@ -40063,7 +40048,7 @@ bool ModMain::DebugExportTurretRegistryJsonl(std::string& detail)
         " enemyNetMapped=" + std::to_string(enemyNetMappedCount) +
         " firing=" + std::to_string(firingCount) +
         " broken=" + std::to_string(brokenCount) +
-        " to " + exportPath.string();
+        " to " + CoopFilesystem::ToUtf8(exportPath);
     m_lastAreaAuthorityEvent = detail;
     LogCoop(detail);
     return true;
@@ -43051,7 +43036,7 @@ bool ModMain::HandleRuntimeControlCommand(const std::string& command, const std:
             " friendlyFireLocal=" + std::to_string(m_identityConfig.Data().friendlyFire ? 1 : 0) +
             " friendlyFireEffective=" + std::to_string(IsSessionFriendlyFireEnabled() ? 1 : 0) +
             " protocol=" + std::to_string(CoopProtocol::kProtocolVersion) +
-            " config=" + StatusToken(m_identityConfig.Path().string()) +
+            " config=" + StatusToken(CoopFilesystem::ToUtf8(m_identityConfig.Path())) +
             " status=" + StatusToken(m_identityConfig.Status());
     }
     else if (command == "coop_identity_selftest")
@@ -43067,7 +43052,7 @@ bool ModMain::HandleRuntimeControlCommand(const std::string& command, const std:
     {
         constexpr uint32_t transferId = 0xFFFFFFFEu;
         const std::string packagePath = BuildCoopReceivedSavePackagePath(transferId);
-        std::ofstream package(packagePath, std::ios::binary | std::ios::trunc);
+        std::ofstream package(CoopFilesystem::FromUtf8(packagePath), std::ios::binary | std::ios::trunc);
         package.write("CORRUPT", 7);
         package.close();
 
@@ -43079,7 +43064,7 @@ bool ModMain::HandleRuntimeControlCommand(const std::string& command, const std:
             extractedPath,
             detail);
         std::error_code removeError;
-        std::filesystem::remove(packagePath, removeError);
+        std::filesystem::remove(CoopFilesystem::FromUtf8(packagePath), removeError);
 
         ok = rejected && detail == "package magic mismatch" && extractedPath.empty();
         action = ok ? "corrupt_save_package_selftest_ok" : "corrupt_save_package_selftest_failed";
@@ -72130,15 +72115,15 @@ bool ModMain::StartHostSaveTransferFromFile(const std::string& sourcePath, uint3
         return false;
     }
 
-    const std::filesystem::path sourceSlotDir = std::filesystem::path(sourcePath).parent_path();
+    const std::filesystem::path sourceSlotDir = CoopFilesystem::FromUtf8(sourcePath).parent_path();
     if (!sourceSlotDir.empty() && sourceSlotDir.filename() == "CoopHostSnapshot")
     {
         std::error_code cleanupError;
         std::filesystem::remove_all(sourceSlotDir, cleanupError);
         if (cleanupError)
-            LogCoop("internal host snapshot cleanup failed: " + sourceSlotDir.string());
+            LogCoop("internal host snapshot cleanup failed: " + CoopFilesystem::ToUtf8(sourceSlotDir));
         else
-            LogCoop("internal host snapshot slot removed: " + sourceSlotDir.string());
+            LogCoop("internal host snapshot slot removed: " + CoopFilesystem::ToUtf8(sourceSlotDir));
     }
 
     uint32_t fileSize = 0;
@@ -72210,7 +72195,7 @@ bool ModMain::QueueNextHostSaveTransferPacket()
         return true;
     }
 
-    std::ifstream stream(m_saveTransferSourcePath, std::ios::binary);
+    std::ifstream stream(CoopFilesystem::FromUtf8(m_saveTransferSourcePath), std::ios::binary);
     if (!stream)
     {
         m_lastSaveTransferEvent = "host save chunk open failed";
@@ -72410,7 +72395,7 @@ std::string ModMain::GetHostPlayerStatePathForUsername(const std::string& userna
     if (safeUsername.empty())
         safeUsername = "Player";
 
-    return (root / ("player_" + SanitizePathComponent(safeUsername) + ".state")).string();
+    return CoopFilesystem::ToUtf8(root / ("player_" + SanitizePathComponent(safeUsername) + ".state"));
 }
 
 std::string ModMain::GetHostPlayerStatePathForUsernameAndSave(const std::string& username, const std::string& saveKey) const
@@ -72424,7 +72409,7 @@ std::string ModMain::GetHostPlayerStatePathForUsernameAndSave(const std::string&
         safeUsername = "Player";
 
     const std::string safeSaveKey = SanitizePathComponent(saveKey.empty() ? std::string("unknown_save") : saveKey);
-    return (saveStateRoot / safeSaveKey / ("player_" + SanitizePathComponent(safeUsername) + ".state")).string();
+    return CoopFilesystem::ToUtf8(saveStateRoot / safeSaveKey / ("player_" + SanitizePathComponent(safeUsername) + ".state"));
 }
 
 std::string ModMain::GetHostPlayerStatePathForAccount(uint64_t accountToken) const
@@ -72432,7 +72417,7 @@ std::string ModMain::GetHostPlayerStatePathForAccount(uint64_t accountToken) con
     const std::filesystem::path root = GetCoopServerPlayerStateRoot();
     if (root.empty() || accountToken == 0)
         return {};
-    return (root / ("player_account_" + Hex64(accountToken) + ".state")).string();
+    return CoopFilesystem::ToUtf8(root / ("player_account_" + Hex64(accountToken) + ".state"));
 }
 
 std::string ModMain::GetHostPlayerStatePathForAccountAndSave(uint64_t accountToken, const std::string& saveKey) const
@@ -72441,7 +72426,7 @@ std::string ModMain::GetHostPlayerStatePathForAccountAndSave(uint64_t accountTok
     if (root.empty() || accountToken == 0)
         return {};
     const std::string safeSaveKey = SanitizePathComponent(saveKey.empty() ? std::string("unknown_save") : saveKey);
-    return (root / safeSaveKey / ("player_account_" + Hex64(accountToken) + ".state")).string();
+    return CoopFilesystem::ToUtf8(root / safeSaveKey / ("player_account_" + Hex64(accountToken) + ".state"));
 }
 
 std::string ModMain::BuildHostSaveStateKey(const std::string& savePathOrName) const
@@ -72541,7 +72526,7 @@ bool ModMain::WriteDefaultHostPlayerStateFile(const std::string& path, const std
     if (path.empty())
         return false;
 
-    const std::filesystem::path filePath(path);
+    const std::filesystem::path filePath = CoopFilesystem::FromUtf8(path);
     std::error_code error;
     std::filesystem::create_directories(filePath.parent_path(), error);
     if (error)
@@ -72674,7 +72659,7 @@ uint32_t ModMain::SnapshotLatestHostPlayerStatesForSave(const std::string& saveK
         if (!std::filesystem::is_regular_file(sourcePath, fileError) || fileError)
             continue;
 
-        const std::string fileName = sourcePath.filename().string();
+        const std::string fileName = CoopFilesystem::ToUtf8(sourcePath.filename());
         if (fileName.rfind("player_", 0) != 0 || sourcePath.extension() != ".state")
             continue;
 
@@ -72753,14 +72738,16 @@ bool ModMain::BeginHostPlayerStateTransfer(const char* reason, const std::string
     {
         if (legacyPath.empty() || accountPath.empty())
             return;
+        const std::filesystem::path legacyFsPath = CoopFilesystem::FromUtf8(legacyPath);
+        const std::filesystem::path accountFsPath = CoopFilesystem::FromUtf8(accountPath);
         std::error_code error;
-        if (std::filesystem::exists(accountPath, error) || error || !std::filesystem::is_regular_file(legacyPath, error))
+        if (std::filesystem::exists(accountFsPath, error) || error || !std::filesystem::is_regular_file(legacyFsPath, error))
             return;
         error.clear();
-        std::filesystem::create_directories(std::filesystem::path(accountPath).parent_path(), error);
+        std::filesystem::create_directories(accountFsPath.parent_path(), error);
         if (error)
             return;
-        std::filesystem::copy_file(legacyPath, accountPath, std::filesystem::copy_options::overwrite_existing, error);
+        std::filesystem::copy_file(legacyFsPath, accountFsPath, std::filesystem::copy_options::overwrite_existing, error);
     };
     migrateLegacyState(previousFormatAccountPath, saveScopedPath);
     // Username-keyed state predates persistent PlayerAccountId and cannot be
@@ -72777,14 +72764,14 @@ bool ModMain::BeginHostPlayerStateTransfer(const char* reason, const std::string
     const bool hasSaveScopedState =
         !saveScopedPath.empty() &&
         ValidatePlayerStateIntegrityFile(
-            std::filesystem::path(saveScopedPath),
+            CoopFilesystem::FromUtf8(saveScopedPath),
             &fileSize,
             &saveScopedHasHash,
             &saveScopedIntegrityReason);
     const bool hasLatestState =
         !latestPath.empty() &&
         ValidatePlayerStateIntegrityFile(
-            std::filesystem::path(latestPath),
+            CoopFilesystem::FromUtf8(latestPath),
             &latestFileSize,
             &latestHasHash,
             &latestIntegrityReason);
@@ -72792,7 +72779,7 @@ bool ModMain::BeginHostPlayerStateTransfer(const char* reason, const std::string
     std::error_code saveScopedStatusError;
     const std::filesystem::file_status saveScopedStatus =
         saveScopedPath.empty() ? std::filesystem::file_status() :
-        std::filesystem::symlink_status(std::filesystem::path(saveScopedPath), saveScopedStatusError);
+        std::filesystem::symlink_status(CoopFilesystem::FromUtf8(saveScopedPath), saveScopedStatusError);
     const bool saveScopedStatusFailed =
         saveScopedStatusError &&
         saveScopedStatusError != std::errc::no_such_file_or_directory;
@@ -72859,7 +72846,7 @@ bool ModMain::BeginHostPlayerStateTransfer(const char* reason, const std::string
     }
 
     uint32_t flags = CoopProtocol::kPlayerStateTransferFlagHostAuthoritative;
-    if (createDefaultState || !IsReadableFile(std::filesystem::path(sourcePath), &fileSize))
+    if (createDefaultState || !IsReadableFile(CoopFilesystem::FromUtf8(sourcePath), &fileSize))
     {
         if (!WriteDefaultHostPlayerStateFile(sourcePath, username))
             return false;
@@ -73627,7 +73614,7 @@ bool ModMain::PrepareReceivedHostSaveForNativePlayerMerge(const char* reason)
         return fail("missing_received_host_save_path");
 
     uint32_t saveSize = 0;
-    if (!IsReadableFile(std::filesystem::path(m_saveTransferReceivePath), &saveSize))
+    if (!IsReadableFile(CoopFilesystem::FromUtf8(m_saveTransferReceivePath), &saveSize))
         return fail("host_save_file_unreadable");
 
     uint32_t saveChecksum = 0;
@@ -73687,7 +73674,7 @@ bool ModMain::PrepareReceivedHostSaveForNativePlayerMerge(const char* reason)
             StatusToken(CoopPreloadSaveMerge::BuildStatus(mergeResult)));
     }
 
-    m_saveTransferReceivePath = mergeResult.mergedSavePath.string();
+    m_saveTransferReceivePath = CoopFilesystem::ToUtf8(mergeResult.mergedSavePath);
     m_nativePreloadSaveMergeOutputPath = m_saveTransferReceivePath;
     m_nativePreloadSaveMergePatched = mergeResult.patched ? 1u : 0u;
     m_lastNativeFragmentImportPayload = state.nativeCapture.nativeFragmentPayload;
@@ -73704,7 +73691,7 @@ bool ModMain::PrepareReceivedHostSaveForNativePlayerMerge(const char* reason)
         mergeResult.wroteNativeSnapshotSave &&
         !mergeResult.nativeSnapshotSavePath.empty()
             ? ProbeScratchNativeLoadStoreFromSave(
-                mergeResult.nativeSnapshotSavePath.string(),
+                CoopFilesystem::ToUtf8(mergeResult.nativeSnapshotSavePath),
                 "preload native player donor snapshot")
             : false;
 
@@ -73823,7 +73810,7 @@ bool ModMain::StartPlayerStateTransferFromFile(const std::string& sourcePath, co
     bool hasIntegrityHash = false;
     std::string integrityReason;
     if (!ValidatePlayerStateIntegrityFile(
-            std::filesystem::path(sourcePath),
+            CoopFilesystem::FromUtf8(sourcePath),
             &fileSize,
             &hasIntegrityHash,
             &integrityReason))
@@ -73934,7 +73921,7 @@ bool ModMain::QueueNextPlayerStateTransferPacket()
         return true;
     }
 
-    std::ifstream stream(m_playerStateTransferSourcePath, std::ios::binary);
+    std::ifstream stream(CoopFilesystem::FromUtf8(m_playerStateTransferSourcePath), std::ios::binary);
     if (!stream)
     {
         m_playerStateTransferSending = false;
@@ -74260,14 +74247,14 @@ bool ModMain::ExportAreaJournalTransferFile(const std::string& levelName, uint32
     outPath = BuildCoopTempAreaJournalPath(transferId, normalizedLevel);
 
     std::error_code error;
-    std::filesystem::create_directories(std::filesystem::path(outPath).parent_path(), error);
+    std::filesystem::create_directories(CoopFilesystem::FromUtf8(outPath).parent_path(), error);
     if (error)
     {
         m_lastAreaJournalTransferEvent = "area journal export mkdir failed";
         return false;
     }
 
-    std::ofstream output(outPath, std::ios::binary | std::ios::trunc);
+    std::ofstream output(CoopFilesystem::FromUtf8(outPath), std::ios::binary | std::ios::trunc);
     if (!output)
     {
         m_lastAreaJournalTransferEvent = "area journal export open failed";
@@ -74519,7 +74506,7 @@ bool ModMain::QueueNextAreaJournalTransferPacket()
         return true;
     }
 
-    std::ifstream stream(m_areaJournalTransferSourcePath, std::ios::binary);
+    std::ifstream stream(CoopFilesystem::FromUtf8(m_areaJournalTransferSourcePath), std::ios::binary);
     if (!stream)
     {
         m_areaJournalTransferSending = false;
@@ -74756,7 +74743,7 @@ bool ModMain::StoreReceivedAreaJournalTransfer(const char* reason)
 
     error.clear();
     std::filesystem::copy_file(
-        std::filesystem::path(m_areaJournalTransferReceivePath),
+        CoopFilesystem::FromUtf8(m_areaJournalTransferReceivePath),
         dest,
         std::filesystem::copy_options::overwrite_existing,
         error);
@@ -74797,7 +74784,7 @@ bool ModMain::StoreReceivedAreaJournalTransfer(const char* reason)
                 LogCoop("remote area handoff request satisfied by incoming area journal level=" + m_areaJournalTransferLevel);
             }
             MergeReceivedAreaJournalIntoServerState("same-level area handoff", true);
-            QueueAreaStateOverlayApply(m_areaJournalTransferLevel, dest.string(), "received same-level area handoff");
+            QueueAreaStateOverlayApply(m_areaJournalTransferLevel, CoopFilesystem::ToUtf8(dest), "received same-level area handoff");
         }
         else
         {
@@ -74819,7 +74806,7 @@ bool ModMain::StoreReceivedAreaJournalTransfer(const char* reason)
         }
         else
         {
-            QueueAreaStateOverlayApply(m_areaJournalTransferLevel, dest.string(), "received server area state");
+            QueueAreaStateOverlayApply(m_areaJournalTransferLevel, CoopFilesystem::ToUtf8(dest), "received server area state");
         }
     }
 
@@ -74859,13 +74846,13 @@ bool ModMain::MergeReceivedAreaJournalIntoServerState(const char* reason, bool a
             " remote=" + remoteLevelName);
     }
 
-    const std::filesystem::path source(m_areaJournalTransferReceivePath);
+    const std::filesystem::path source = CoopFilesystem::FromUtf8(m_areaJournalTransferReceivePath);
     uint32_t fileSize = 0;
     if (!IsReadableFile(source, &fileSize))
         return reject("server area merge rejected: unreadable receive file");
 
     uint32_t checksum = 0;
-    if (!ComputeFileChecksum(source.string(), checksum))
+    if (!ComputeFileChecksum(CoopFilesystem::ToUtf8(source), checksum))
         return reject("server area merge rejected: checksum failed");
 
     const std::filesystem::path root = GetCoopServerAreaStateRoot();
@@ -74967,7 +74954,7 @@ bool ModMain::BeginServerAreaStateTransfer(const std::string& requestedLevelName
     }
 
     const uint32_t transferId = ++m_areaJournalTransferId;
-    if (!StartAreaJournalTransferFromFile(source.string(), levelName, transferId))
+    if (!StartAreaJournalTransferFromFile(CoopFilesystem::ToUtf8(source), levelName, transferId))
     {
         ++m_serverAreaStateRejectCount;
         m_lastServerAreaStateEvent = "server area send rejected: transfer start failed level=" + levelName;
@@ -74995,7 +74982,7 @@ bool ModMain::QueueAreaStateOverlayApply(const std::string& levelName, const std
     }
 
     uint32_t fileSize = 0;
-    if (!IsReadableFile(std::filesystem::path(sourcePath), &fileSize))
+    if (!IsReadableFile(CoopFilesystem::FromUtf8(sourcePath), &fileSize))
     {
         ++m_areaOverlayApplyFailCount;
         m_lastAreaOverlayEvent = "area overlay queue rejected: unreadable file level=" + normalizedLevel;
@@ -75037,7 +75024,7 @@ bool ModMain::QueueServerAreaStateOverlayForLevel(const std::string& levelName, 
         return false;
     }
 
-    return QueueAreaStateOverlayApply(normalizedLevel, source.string(), reason && reason[0] ? reason : "server area state");
+    return QueueAreaStateOverlayApply(normalizedLevel, CoopFilesystem::ToUtf8(source), reason && reason[0] ? reason : "server area state");
 }
 
 bool ModMain::QueueReceivedAreaStateOverlayForLevel(const std::string& levelName, const char* reason)
@@ -75063,7 +75050,7 @@ bool ModMain::QueueReceivedAreaStateOverlayForLevel(const std::string& levelName
             break;
         if (!entry.is_regular_file(error) || error)
             continue;
-        const std::string fileName = entry.path().filename().string();
+        const std::string fileName = CoopFilesystem::ToUtf8(entry.path().filename());
         if (fileName.rfind("journal_", 0) != 0 || entry.path().extension() != ".jsonl")
             continue;
 
@@ -75087,7 +75074,7 @@ bool ModMain::QueueReceivedAreaStateOverlayForLevel(const std::string& levelName
         return false;
     }
 
-    return QueueAreaStateOverlayApply(normalizedLevel, newestPath.string(), reason && reason[0] ? reason : "received area state");
+    return QueueAreaStateOverlayApply(normalizedLevel, CoopFilesystem::ToUtf8(newestPath), reason && reason[0] ? reason : "received area state");
 }
 
 bool ModMain::TryApplyQueuedAreaStateOverlay(const char* reason)
@@ -75120,14 +75107,14 @@ bool ModMain::TryApplyQueuedAreaStateOverlay(const char* reason)
     std::vector<uint64_t> transformedGuids;
     m_areaOverlayApplyActive = true;
     bool ok = ApplyCoopAreaStateOverlayJsonl(
-        std::filesystem::path(m_pendingAreaOverlayApplyPath),
+        CoopFilesystem::FromUtf8(m_pendingAreaOverlayApplyPath),
         m_pendingAreaOverlayApplyLevel,
         stats,
         &transformedGuids);
 
     CoopAreaObjectJournal::ReplayStats objectStats;
     const bool objectOk = m_areaObjectJournal.ReplayLevelJsonl(
-        std::filesystem::path(m_pendingAreaOverlayApplyPath),
+        CoopFilesystem::FromUtf8(m_pendingAreaOverlayApplyPath),
         m_pendingAreaOverlayApplyLevel,
         [this](const CoopProtocol::AreaObjectEventPacket& packet, std::string& detail)
         {
@@ -75330,7 +75317,7 @@ void ModMain::HandleAreaJournalTransfer(const CoopProtocol::AreaJournalTransferP
         m_areaJournalTransferStarted = true;
         m_areaJournalTransferComplete = false;
 
-        std::ofstream output(m_areaJournalTransferReceivePath, std::ios::binary | std::ios::trunc);
+        std::ofstream output(CoopFilesystem::FromUtf8(m_areaJournalTransferReceivePath), std::ios::binary | std::ios::trunc);
         if (!output)
         {
             m_lastAreaJournalTransferEvent = "cannot create received area journal";
@@ -75377,7 +75364,7 @@ void ModMain::HandleAreaJournalTransfer(const CoopProtocol::AreaJournalTransferP
             return;
         }
 
-        std::ofstream output(m_areaJournalTransferReceivePath, std::ios::binary | std::ios::app);
+        std::ofstream output(CoopFilesystem::FromUtf8(m_areaJournalTransferReceivePath), std::ios::binary | std::ios::app);
         if (!output)
         {
             m_lastAreaJournalTransferEvent = "received area journal append failed";
@@ -75465,7 +75452,7 @@ void ModMain::HandleSaveTransfer(const CoopProtocol::SaveTransferPacket& packet)
         m_pendingHostWorldRequest = false;
         m_joinOverlayStageOverride = "Downloading map";
 
-        std::ofstream output(m_saveTransferReceivePath, std::ios::binary | std::ios::trunc);
+        std::ofstream output(CoopFilesystem::FromUtf8(m_saveTransferReceivePath), std::ios::binary | std::ios::trunc);
         if (!output)
         {
             m_lastSaveTransferEvent = "cannot create received save package";
@@ -75502,7 +75489,7 @@ void ModMain::HandleSaveTransfer(const CoopProtocol::SaveTransferPacket& packet)
             return;
         }
 
-        std::ofstream output(m_saveTransferReceivePath, std::ios::binary | std::ios::app);
+        std::ofstream output(CoopFilesystem::FromUtf8(m_saveTransferReceivePath), std::ios::binary | std::ios::app);
         if (!output)
         {
             m_lastSaveTransferEvent = "received save append failed";
@@ -75643,7 +75630,7 @@ void ModMain::HandlePlayerStateTransfer(const CoopProtocol::PlayerStateTransferP
                 packet.transferId,
                 receive.username + "_" + Hex64(packet.accountToken));
 
-            std::ofstream output(receive.receivePath, std::ios::binary | std::ios::trunc);
+            std::ofstream output(CoopFilesystem::FromUtf8(receive.receivePath), std::ios::binary | std::ios::trunc);
             if (!output)
             {
                 failUpload(
@@ -75698,7 +75685,7 @@ void ModMain::HandlePlayerStateTransfer(const CoopProtocol::PlayerStateTransferP
                 return;
             }
 
-            std::ofstream output(receive.receivePath, std::ios::binary | std::ios::app);
+            std::ofstream output(CoopFilesystem::FromUtf8(receive.receivePath), std::ios::binary | std::ios::app);
             if (!output)
             {
                 failUpload(
@@ -75757,7 +75744,7 @@ void ModMain::HandlePlayerStateTransfer(const CoopProtocol::PlayerStateTransferP
         const uint64_t accountToken = receive.accountToken;
         const std::string storedUsername = receive.username;
         const std::string storedSaveKey = receive.saveKey;
-        const std::filesystem::path receivePath(receive.receivePath);
+        const std::filesystem::path receivePath = CoopFilesystem::FromUtf8(receive.receivePath);
         const std::string latestPath = GetHostPlayerStatePathForAccount(accountToken);
         if (latestPath.empty())
         {
@@ -75766,7 +75753,7 @@ void ModMain::HandlePlayerStateTransfer(const CoopProtocol::PlayerStateTransferP
         }
 
         std::error_code error;
-        const std::filesystem::path latestDest(latestPath);
+        const std::filesystem::path latestDest = CoopFilesystem::FromUtf8(latestPath);
         std::filesystem::create_directories(latestDest.parent_path(), error);
         if (error)
         {
@@ -75794,7 +75781,7 @@ void ModMain::HandlePlayerStateTransfer(const CoopProtocol::PlayerStateTransferP
                 return;
             }
 
-            const std::filesystem::path scopedDest(scopedPath);
+            const std::filesystem::path scopedDest = CoopFilesystem::FromUtf8(scopedPath);
             error.clear();
             std::filesystem::create_directories(scopedDest.parent_path(), error);
             if (error)
@@ -75870,7 +75857,7 @@ void ModMain::HandlePlayerStateTransfer(const CoopProtocol::PlayerStateTransferP
         m_pendingNativePlayerStateOverride = PlayerSidecarState();
         m_receivedPlayerStateMergedDuringNativeLoad = false;
 
-        std::ofstream output(m_playerStateTransferReceivePath, std::ios::binary | std::ios::trunc);
+        std::ofstream output(CoopFilesystem::FromUtf8(m_playerStateTransferReceivePath), std::ios::binary | std::ios::trunc);
         if (!output)
         {
             m_lastPlayerStateTransferEvent = "cannot create received player state";
@@ -75911,7 +75898,7 @@ void ModMain::HandlePlayerStateTransfer(const CoopProtocol::PlayerStateTransferP
             return;
         }
 
-        std::ofstream output(m_playerStateTransferReceivePath, std::ios::binary | std::ios::app);
+        std::ofstream output(CoopFilesystem::FromUtf8(m_playerStateTransferReceivePath), std::ios::binary | std::ios::app);
         if (!output)
         {
             m_lastPlayerStateTransferEvent = "received player state append failed";
@@ -75960,7 +75947,7 @@ void ModMain::HandlePlayerStateTransfer(const CoopProtocol::PlayerStateTransferP
                 return;
             }
 
-            const std::filesystem::path dest(latestPath);
+            const std::filesystem::path dest = CoopFilesystem::FromUtf8(latestPath);
             std::error_code error;
             std::filesystem::create_directories(dest.parent_path(), error);
             if (error)
@@ -75970,7 +75957,7 @@ void ModMain::HandlePlayerStateTransfer(const CoopProtocol::PlayerStateTransferP
             }
 
             std::filesystem::copy_file(
-                std::filesystem::path(m_playerStateTransferReceivePath),
+                CoopFilesystem::FromUtf8(m_playerStateTransferReceivePath),
                 dest,
                 std::filesystem::copy_options::overwrite_existing,
                 error);
@@ -75985,14 +75972,14 @@ void ModMain::HandlePlayerStateTransfer(const CoopProtocol::PlayerStateTransferP
                 const std::string scopedPath = GetHostPlayerStatePathForAccountAndSave(m_playerStateTransferAccountToken, m_playerStateTransferSaveKey);
                 if (!scopedPath.empty())
                 {
-                    const std::filesystem::path scopedDest(scopedPath);
+                    const std::filesystem::path scopedDest = CoopFilesystem::FromUtf8(scopedPath);
                     error.clear();
                     std::filesystem::create_directories(scopedDest.parent_path(), error);
                     if (!error)
                     {
                         error.clear();
                         std::filesystem::copy_file(
-                            std::filesystem::path(m_playerStateTransferReceivePath),
+                            CoopFilesystem::FromUtf8(m_playerStateTransferReceivePath),
                             scopedDest,
                             std::filesystem::copy_options::overwrite_existing,
                             error);


### PR DESCRIPTION
## Summary
- read Windows profile and temp directories through the wide-character environment API
- keep filesystem operations on native paths and use UTF-8 only at existing string/API boundaries
- make save packages, player sidecars, identity XML, migration, and diagnostic/export paths Unicode-safe

## Verification
- `CHAIRLOADER_COMMON_PATH=/home/null234/Downloads/ChairLoader/Common ./build-msvc.sh`
- `CoopAbiSmokeTest.exe` under Wine: exit 0
- Windows path smoke test under Wine: create/read/rename succeeded for `TestÜser/Клиент/存档`
- independent strict path audit: ACCEPT
- `git diff --check`

Closes #13