### PR TITLE
Harden client inventory recovery

### DIFF
--- a/CoopPrototype/Src/CoopLivePropSync.cpp
+++ b/CoopPrototype/Src/CoopLivePropSync.cpp
@@ -4363,6 +4363,8 @@ void ModMain::DisconnectRemotePeer(const char* reason)
 {
     const std::string status = reason && reason[0] ? reason : "peer disconnected";
     const CoopNetworkMode previousMode = m_networkMode;
+    const bool nativeWindowCloseInProgress =
+        m_nativeWindowCloseDeferred || m_nativeWindowCloseReentry;
     LogCoop("disconnect remote peer begin mode=" + std::string(GetNetworkModeName()) +
         " reason=" + status);
     if (previousMode == CoopNetworkMode::Host)
@@ -4452,7 +4454,11 @@ void ModMain::DisconnectRemotePeer(const char* reason)
     m_networkStatus = status;
     m_sessionStatus = "disconnected";
     m_lastSessionWorldEvent = status;
-    QueueCoopHudFeedback("DISCONNECTED - " + status, 3.0f);
+    // Keep the explicit saving notice visible until the deferred native close
+    // has been reposted. A generic disconnect notice would otherwise replace
+    // it in the single-slot HUD queue during the same update.
+    if (!nativeWindowCloseInProgress)
+        QueueCoopHudFeedback("DISCONNECTED - " + status, 3.0f);
     LogCoop(status);
 
     if (previousMode == CoopNetworkMode::Client)

--- a/CoopPrototype/Src/CoopNativeInventoryBridge.cpp
+++ b/CoopPrototype/Src/CoopNativeInventoryBridge.cpp
@@ -1431,6 +1431,8 @@ void ModMain::OnArkInventoryMutationHook(
 
     ArkPlayer* player = ArkPlayer::GetInstancePtr();
     const bool localPlayerInventory = player && inventory && inventory == player->m_pInventory;
+    if (localPlayerInventory && boolResult && !ShouldSuppressPlayerSidecarInventoryFeedback())
+        MarkLocalInventoryDirty(functionName ? functionName : "inventory mutation");
     if (ShouldLogNativeInventoryTraceDetails() && m_nativeInventoryTraceLogs++ < kNativeInventoryTraceLogLimit)
     {
         m_lastNativeItemEvent = std::string("Inventory ") +
@@ -1461,6 +1463,13 @@ void ModMain::OnArkItemOwnerMutationHook(
     bool result)
 {
     ++m_nativeItemOwnerMutationCalls;
+    ArkPlayer* player = ArkPlayer::GetInstancePtr();
+    const bool localPlayerInventory =
+        player && inventory && inventory == player->m_pInventory;
+    const bool localPicker =
+        player && pickerId != 0 && player->GetEntity() && player->GetEntity()->GetId() == pickerId;
+    if ((localPlayerInventory || localPicker) && result && !ShouldSuppressPlayerSidecarInventoryFeedback())
+        MarkLocalInventoryDirty(functionName ? functionName : "item owner mutation");
     if (ShouldLogNativeInventoryTraceDetails() && m_nativeInventoryTraceLogs++ < kNativeInventoryTraceLogLimit)
     {
         m_lastNativeItemEvent = std::string("CArkItem ") +
@@ -1480,17 +1489,46 @@ void ModMain::OnArkItemOwnerMutationHook(
     }
 }
 
-void ModMain::OnArkItemResetCountHook(CArkItem* item, int count)
+void ModMain::OnArkItemResetCountHook(CArkItem* item, int count, unsigned ownerIdBefore)
 {
+    ArkPlayer* player = ArkPlayer::GetInstancePtr();
+    const unsigned localPlayerId = player ? player->GetEntityId() : 0;
+    const bool localPlayerOwnedItem =
+        ownerIdBefore != 0 && localPlayerId != 0 && ownerIdBefore == localPlayerId;
+    const bool inventoryLoadOrRestoreHazard =
+        m_saveLoadGuardActive ||
+        m_waitingForPostLoadContinue ||
+        m_pendingPostLoadResync ||
+        m_arkLevelTransitionLoadActive ||
+        m_runtimeTransitionCleanupPrepared ||
+        m_pendingReceivedPlayerStateApply ||
+        m_clientAwaitingHostPlayerState ||
+        m_pendingPlayerSidecarInventoryRestore ||
+        m_playerSidecarInventoryNativeRestoreActive ||
+        m_playerSidecarInventoryPending > 0;
+    if (localPlayerOwnedItem &&
+        !inventoryLoadOrRestoreHazard &&
+        !ShouldSuppressPlayerSidecarInventoryFeedback())
+    {
+        // ResetCount(0) can detach the item and clear its owner. The hook
+        // captures that owner before native ResetCount so stack consumption
+        // still arms the recovery journal without marking restore activity.
+        MarkLocalInventoryDirty("CArkItem ResetCount");
+    }
+
     if (ShouldLogNativeInventoryTraceDetails() && m_nativeInventoryTraceLogs++ < kNativeInventoryTraceLogLimit)
     {
         m_lastNativeItemEvent = "CArkItem ResetCount count=" +
             std::to_string(count) +
+            " ownerBefore=" + std::to_string(ownerIdBefore) +
+            " local=" + BoolText(localPlayerOwnedItem) +
             " " + DescribeCArkItemForTrace(item);
         LogCoop("native item trace " + m_lastNativeItemEvent);
     }
     else
     {
-        m_lastNativeItemEvent = "CArkItem ResetCount trace=off count=" + std::to_string(count);
+        m_lastNativeItemEvent = "CArkItem ResetCount trace=off count=" +
+            std::to_string(count) + " ownerBefore=" + std::to_string(ownerIdBefore) +
+            " local=" + BoolText(localPlayerOwnedItem);
     }
 }

--- a/CoopPrototype/Src/CoopPlayerSidecar.cpp
+++ b/CoopPrototype/Src/CoopPlayerSidecar.cpp
@@ -2948,6 +2948,49 @@ void ModMain::MarkLocalInventoryDirty(const char* reason)
         m_lastPlayerSidecarEvent = "local inventory dirty: " + std::string(reason);
 }
 
+void ModMain::CaptureLocalPlayerPickupRecovery(EntityId pickerId, const char* reason)
+{
+    if (m_networkMode != CoopNetworkMode::Client ||
+        !m_enablePlayerSidecar ||
+        !ArkPlayer::GetInstancePtr() ||
+        pickerId != ArkPlayer::GetInstance().GetEntityId())
+    {
+        return;
+    }
+
+    // PickUp can run from the shared-drop commit while m_sharedDropApplyDepth
+    // is non-zero. Capture here, after native PickUp has returned, instead of
+    // relying on the normal debounced tick which an immediate process kill can
+    // precede.
+    MarkLocalInventoryDirty("successful local-player pickup");
+    const std::string saveKey = m_currentHostSaveStateKey;
+    if (!IsLocalInventoryDirtyForSaveKey(saveKey))
+        return;
+
+    const uint64_t capturedRevision = m_localInventoryDirtyRevision;
+    const std::string captureReason =
+        std::string("recovery journal: successful local-player pickup") +
+        (reason && reason[0] ? " (" + std::string(reason) + ")" : "");
+    const bool sidecarSaved = SaveLocalPlayerSidecar(captureReason.c_str());
+    const bool journalWritten = sidecarSaved &&
+        WriteLocalPlayerRecoveryJournal(captureReason.c_str());
+    if (sidecarSaved && journalWritten && capturedRevision == m_localInventoryDirtyRevision)
+    {
+        m_localInventoryDirty = false;
+        m_localInventoryDirtySaveKey.clear();
+        m_localInventoryJournalAccumulator = 0.0f;
+        return;
+    }
+
+    // Keep the dirty marker armed when either capture step cannot complete.
+    // TickPlayerSidecar will retry with the same exact host save key.
+    m_localInventoryJournalAccumulator = 0.0f;
+    LogCoop(
+        "immediate local pickup recovery capture deferred saveKey=" + saveKey +
+        " sidecar=" + std::to_string(sidecarSaved ? 1 : 0) +
+        " journal=" + std::to_string(journalWritten ? 1 : 0));
+}
+
 bool ModMain::SaveLocalPlayerSidecar(const char* reason)
 {
     if (!m_enablePlayerSidecar)

--- a/CoopPrototype/Src/CoopPlayerSidecar.cpp
+++ b/CoopPrototype/Src/CoopPlayerSidecar.cpp
@@ -17,6 +17,7 @@
 #include <fstream>
 #include <iomanip>
 #include <locale>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -24,6 +25,10 @@
 #include <vector>
 
 #include <boost/variant/get.hpp>
+
+#ifdef _WIN32
+#include <Windows.h>
+#endif
 
 #include <Chairloader/IChairLogger.h>
 #include <Prey/CryEntitySystem/IEntity.h>
@@ -319,15 +324,146 @@ bool WritePlayerSidecarPayloadWithHash(const std::filesystem::path& path, const 
         return false;
 
     std::error_code error;
+#ifdef _WIN32
+    // Rename is not a replacement operation on Windows. Use the same
+    // write-through replacement as the transfer commit path so a power loss
+    // cannot leave a partially written recovery journal as the only copy.
+    if (MoveFileExW(
+            tempPath.c_str(),
+            path.c_str(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
+    {
+        return true;
+    }
+    return false;
+#else
     std::filesystem::rename(tempPath, path, error);
     if (!error)
         return true;
+#endif
 
     error.clear();
     std::filesystem::copy_file(tempPath, path, std::filesystem::copy_options::overwrite_existing, error);
     std::error_code removeError;
     std::filesystem::remove(tempPath, removeError);
     return !error;
+}
+
+struct RecoveryJournalMetadata
+{
+    uint64_t accountToken = 0;
+    uint64_t revision = 0;
+    std::string saveKey;
+};
+
+bool StartsWith(std::string_view value, std::string_view prefix);
+std::string AfterPrefix(std::string_view value, std::string_view prefix);
+
+bool ParseRecoveryJournalUint64(std::string_view text, uint64_t& value)
+{
+    if (text.empty() || text.size() > 16)
+        return false;
+
+    value = 0;
+    for (const char ch : text)
+    {
+        value <<= 4;
+        if (ch >= '0' && ch <= '9')
+            value |= static_cast<uint64_t>(ch - '0');
+        else if (ch >= 'a' && ch <= 'f')
+            value |= static_cast<uint64_t>(10 + ch - 'a');
+        else if (ch >= 'A' && ch <= 'F')
+            value |= static_cast<uint64_t>(10 + ch - 'A');
+        else
+            return false;
+    }
+    return value != 0;
+}
+
+bool ParseRecoveryJournalMetadata(
+    const std::string& pathString,
+    RecoveryJournalMetadata& metadata,
+    std::string* outPayload = nullptr)
+{
+    metadata = {};
+    std::string payload;
+    bool hasIntegrityHash = false;
+    std::string integrityReason;
+    if (!ReadAndValidatePlayerSidecarFile(
+            pathString,
+            payload,
+            hasIntegrityHash,
+            integrityReason) ||
+        !hasIntegrityHash)
+    {
+        return false;
+    }
+
+    bool hasAccount = false;
+    bool hasSaveKey = false;
+    bool hasRevision = false;
+    std::istringstream input(payload);
+    input.imbue(std::locale::classic());
+    std::string line;
+    while (std::getline(input, line))
+    {
+        if (StartsWith(line, "recoveryAccount="))
+            hasAccount = ParseRecoveryJournalUint64(AfterPrefix(line, "recoveryAccount="), metadata.accountToken);
+        else if (StartsWith(line, "recoverySaveKey="))
+        {
+            metadata.saveKey = AfterPrefix(line, "recoverySaveKey=");
+            hasSaveKey = !metadata.saveKey.empty();
+        }
+        else if (StartsWith(line, "recoveryRevision="))
+        {
+            std::istringstream revisionStream(AfterPrefix(line, "recoveryRevision="));
+            revisionStream.imbue(std::locale::classic());
+            revisionStream >> metadata.revision;
+            hasRevision = !revisionStream.fail() && metadata.revision != 0;
+        }
+    }
+
+    if (outPayload)
+        *outPayload = std::move(payload);
+    return hasAccount && hasSaveKey && hasRevision;
+}
+
+uint64_t GetRecoveryJournalDiskMaxRevision(
+    const std::filesystem::path& root,
+    uint64_t accountToken)
+{
+    if (root.empty() || accountToken == 0)
+        return 0;
+
+    const std::string filePrefix =
+        "player_recovery_account_" + HexPlayerAccountToken(accountToken) + "_";
+    uint64_t maxRevision = 0;
+    std::error_code error;
+    for (std::filesystem::directory_iterator it(root, error), end; it != end; it.increment(error))
+    {
+        if (error)
+        {
+            error.clear();
+            continue;
+        }
+
+        const std::filesystem::path candidate = it->path();
+        std::error_code fileError;
+        if (!std::filesystem::is_regular_file(candidate, fileError) || fileError)
+            continue;
+
+        const std::string fileName = CoopFilesystem::ToUtf8(candidate.filename());
+        if (candidate.extension() != ".state" || !StartsWith(fileName, filePrefix))
+            continue;
+
+        RecoveryJournalMetadata metadata;
+        if (ParseRecoveryJournalMetadata(CoopFilesystem::ToUtf8(candidate), metadata) &&
+            metadata.accountToken == accountToken)
+        {
+            maxRevision = std::max(maxRevision, metadata.revision);
+        }
+    }
+    return maxRevision;
 }
 
 bool ShouldApplyPlayerSidecarTransform(const IEntity& entity, const Vec3& position, const Quat& rotation)
@@ -2522,6 +2658,296 @@ std::string ModMain::GetPlayerSidecarPath() const
     return CoopFilesystem::ToUtf8(root / fileName);
 }
 
+std::string ModMain::GetPlayerSidecarRecoveryJournalPath() const
+{
+    const uint64_t accountToken = GetLocalAccountToken();
+    if (accountToken == 0)
+        return {};
+
+    // Recovery belongs to the exact host save identity advertised for the
+    // current session. Do not infer a key from a transfer or local load path:
+    // either can still describe the previous session during reconnect.
+    const std::string& saveKey = m_currentHostSaveStateKey;
+    if (saveKey.empty() || saveKey == "unknown_save")
+        return {};
+
+    const std::filesystem::path root = GetCoopPlayerStateRoot();
+    if (root.empty())
+        return {};
+
+    return CoopFilesystem::ToUtf8(
+        root / ("player_recovery_account_" + HexPlayerAccountToken(accountToken) +
+            "_" + SanitizePathComponent(saveKey) + ".state"));
+}
+
+bool ModMain::HasValidPlayerSidecarRecoveryJournal() const
+{
+    const std::string pathString = GetPlayerSidecarRecoveryJournalPath();
+    if (pathString.empty())
+        return false;
+
+    RecoveryJournalMetadata metadata;
+    if (!ParseRecoveryJournalMetadata(pathString, metadata))
+        return false;
+
+    const std::string& expectedSaveKey = m_currentHostSaveStateKey;
+    return metadata.accountToken == GetLocalAccountToken() &&
+        metadata.saveKey == expectedSaveKey &&
+        metadata.revision != 0;
+}
+
+uint64_t ModMain::GetPlayerSidecarRecoveryJournalRevision() const
+{
+    const std::string pathString = GetPlayerSidecarRecoveryJournalPath();
+    if (pathString.empty())
+        return 0;
+
+    RecoveryJournalMetadata metadata;
+    return ParseRecoveryJournalMetadata(pathString, metadata) ? metadata.revision : 0;
+}
+
+bool ModMain::WriteLocalPlayerRecoveryJournal(const char* reason)
+{
+    const std::string journalPathString = GetPlayerSidecarRecoveryJournalPath();
+    const std::string sourcePathString = GetPlayerSidecarPath();
+    if (journalPathString.empty() || sourcePathString.empty())
+        return false;
+
+    std::string payload;
+    bool hasIntegrityHash = false;
+    std::string integrityReason;
+    if (!ReadAndValidatePlayerSidecarFile(
+            sourcePathString,
+            payload,
+            hasIntegrityHash,
+            integrityReason) ||
+        !hasIntegrityHash)
+    {
+        LogCoop(
+            "player recovery journal skipped: sidecar unreadable reason=" +
+            (integrityReason.empty() ? std::string("invalid") : integrityReason));
+        return false;
+    }
+
+    const uint64_t accountToken = GetLocalAccountToken();
+    const std::string& saveKey = m_currentHostSaveStateKey;
+    if (saveKey.empty() || saveKey == "unknown_save")
+        return false;
+    if (m_networkMode == CoopNetworkMode::Client &&
+        m_localInventoryDirty &&
+        !IsLocalInventoryDirtyForSaveKey(saveKey))
+    {
+        LogCoop("player recovery journal skipped: dirty state belongs to another saveKey");
+        return false;
+    }
+
+    // The dirty counter is process-local. Use the highest valid durable
+    // revision for this account (including other save-key files) so a fresh
+    // process cannot reuse an older revision after restart.
+    uint64_t durableRevision = GetRecoveryJournalDiskMaxRevision(
+        GetCoopPlayerStateRoot(), accountToken);
+    durableRevision = std::max(durableRevision, m_localInventoryJournalRevision);
+    if (durableRevision == std::numeric_limits<uint64_t>::max())
+    {
+        LogCoop("player recovery journal write failed: revision exhausted");
+        return false;
+    }
+    const uint64_t revision = durableRevision + 1;
+
+    if (!payload.empty() && payload.back() != '\n')
+        payload.push_back('\n');
+    payload += "recoveryAccount=" + HexPlayerAccountToken(accountToken) + "\n";
+    payload += "recoverySaveKey=" + saveKey + "\n";
+    payload += "recoveryRevision=" + std::to_string(revision) + "\n";
+
+    const std::filesystem::path journalPath = CoopFilesystem::FromUtf8(journalPathString);
+    std::error_code error;
+    std::filesystem::create_directories(journalPath.parent_path(), error);
+    if (error || !WritePlayerSidecarPayloadWithHash(journalPath, payload))
+    {
+        LogCoop("player recovery journal write failed saveKey=" + saveKey);
+        return false;
+    }
+
+    m_localInventoryJournalRevision = revision;
+    m_lastPlayerSidecarEvent =
+        "wrote player recovery journal revision=" + std::to_string(revision) +
+        (reason && reason[0] ? ": " + std::string(reason) : "");
+    LogCoop("player recovery journal " + m_lastPlayerSidecarEvent);
+    return true;
+}
+
+bool ModMain::ClearLocalPlayerRecoveryJournal(
+    const std::string& sourcePath,
+    uint64_t accountToken,
+    const std::string& saveKey,
+    uint64_t revision,
+    const char* reason)
+{
+    if (sourcePath.empty() || accountToken == 0 || saveKey.empty() || revision == 0)
+        return false;
+
+    RecoveryJournalMetadata metadata;
+    if (!ParseRecoveryJournalMetadata(sourcePath, metadata) ||
+        metadata.accountToken != accountToken ||
+        metadata.saveKey != saveKey ||
+        metadata.revision != revision)
+        return false;
+
+    // A mutation can arrive while the transfer is in flight. Never let an ack
+    // for the older immutable snapshot erase that newer local recovery point.
+    if (IsLocalInventoryDirtyForSaveKey(saveKey))
+        return false;
+
+    std::error_code error;
+    std::filesystem::remove(CoopFilesystem::FromUtf8(sourcePath), error);
+    if (!error || error == std::errc::no_such_file_or_directory)
+    {
+        // Retain the last acknowledged revision in memory. The next dirty
+        // rewrite must still be greater than this revision even if the file
+        // was removed before the process is restarted.
+        m_localInventoryJournalRevision = std::max(m_localInventoryJournalRevision, revision);
+        m_localInventoryDirtySaveKey.clear();
+        m_lastPlayerSidecarEvent =
+            "cleared player recovery journal" +
+            (reason && reason[0] ? ": " + std::string(reason) : "");
+        LogCoop("player recovery journal " + m_lastPlayerSidecarEvent);
+        return true;
+    }
+    return false;
+}
+
+bool ModMain::RecoverLocalPlayerRecoveryJournal(const char* reason)
+{
+    if (m_networkMode != CoopNetworkMode::Client)
+        return false;
+
+    // A host save handover invalidates the previous in-flight upload. Keep
+    // that save's journal on disk, but never let its transport state block
+    // recovery for the newly advertised host key.
+    if (m_clientRecoveryJournalPending &&
+        !m_currentHostSaveStateKey.empty() &&
+        m_clientRecoveryJournalSaveKey != m_currentHostSaveStateKey)
+    {
+        m_clientRecoveryJournalPending = false;
+        m_clientRecoveryJournalAwaitingStoredAck = false;
+        m_clientRecoveryJournalStoredAckReceived = false;
+        m_clientRecoveryJournalTransferId = 0;
+        m_clientRecoveryJournalChecksum = 0;
+        m_clientRecoveryJournalRevision = 0;
+        m_clientRecoveryJournalSourcePath.clear();
+        m_clientRecoveryJournalSaveKey.clear();
+    }
+
+    const std::string pathString = GetPlayerSidecarRecoveryJournalPath();
+    if (pathString.empty())
+        return false;
+
+    RecoveryJournalMetadata metadata;
+    if (!ParseRecoveryJournalMetadata(pathString, metadata) ||
+        metadata.accountToken != GetLocalAccountToken())
+    {
+        return false;
+    }
+
+    const std::string& expectedSaveKey = m_currentHostSaveStateKey;
+    if (expectedSaveKey.empty() || expectedSaveKey == "unknown_save")
+        return false;
+    if (metadata.saveKey != expectedSaveKey || metadata.revision == 0)
+        return false;
+
+    PlayerSidecarState state;
+    if (!LoadPlayerSidecarFromPath(pathString, state))
+    {
+        LogCoop("player recovery journal rejected: sidecar parse failed saveKey=" + metadata.saveKey);
+        return false;
+    }
+
+    if (m_clientRecoveryJournalPending &&
+        m_clientRecoveryJournalSourcePath == pathString &&
+        m_clientRecoveryJournalRevision == metadata.revision)
+    {
+        return true;
+    }
+
+    m_localInventoryJournalRevision = std::max(m_localInventoryJournalRevision, metadata.revision);
+    m_clientRecoveryJournalPending = true;
+    m_clientRecoveryJournalAwaitingStoredAck = false;
+    m_clientRecoveryJournalStoredAckReceived = false;
+    m_clientRecoveryJournalTransferId = 0;
+    m_clientRecoveryJournalChecksum = 0;
+    m_clientRecoveryJournalRevision = metadata.revision;
+    m_clientRecoveryJournalSourcePath = pathString;
+    m_clientRecoveryJournalSaveKey = metadata.saveKey;
+    m_lastPlayerStateTransferEvent =
+        "pending newer player recovery journal revision=" +
+        std::to_string(metadata.revision) + " saveKey=" + metadata.saveKey +
+        (reason && reason[0] ? ": " + std::string(reason) : "");
+    LogCoop(m_lastPlayerStateTransferEvent);
+    return true;
+}
+
+bool ModMain::IsLocalInventoryDirtyForSaveKey(const std::string& saveKey) const
+{
+    return m_localInventoryDirty &&
+        !saveKey.empty() &&
+        saveKey != "unknown_save" &&
+        m_localInventoryDirtySaveKey == saveKey;
+}
+
+void ModMain::ReconcileLocalInventoryDirtyForSaveKey(const std::string& saveKey)
+{
+    if (m_networkMode != CoopNetworkMode::Client ||
+        !m_localInventoryDirty ||
+        saveKey.empty() ||
+        saveKey == "unknown_save" ||
+        m_localInventoryDirtySaveKey == saveKey)
+    {
+        return;
+    }
+
+    // A dirty snapshot is only valid for the host/save identity that was
+    // active when the mutation happened. Keep the old keyed recovery journal
+    // on disk for a same-key reconnect, but never carry its in-memory dirty
+    // bit into a different campaign or host save.
+    LogCoop(
+        "discarded stale local inventory dirty state oldSaveKey=" +
+        (m_localInventoryDirtySaveKey.empty() ? std::string("-") : m_localInventoryDirtySaveKey) +
+        " newSaveKey=" + saveKey);
+    m_localInventoryDirty = false;
+    m_localInventoryDirtySaveKey.clear();
+    m_localInventoryJournalAccumulator = 0.0f;
+}
+
+void ModMain::MarkLocalInventoryDirty(const char* reason)
+{
+    if (!m_enablePlayerSidecar || ShouldSuppressPlayerSidecarInventoryFeedback())
+        return;
+
+    // Before the host identity handshake there is no safe destination for a
+    // client mutation. Dropping the unscoped dirty bit is safer than later
+    // uploading pre-join inventory to an unrelated host/save.
+    if (m_networkMode == CoopNetworkMode::Client &&
+        (m_currentHostSaveStateKey.empty() || m_currentHostSaveStateKey == "unknown_save"))
+    {
+        LogCoop("ignored unscoped local inventory mutation before host save identity");
+        return;
+    }
+
+    if (m_networkMode == CoopNetworkMode::Client)
+    {
+        ReconcileLocalInventoryDirtyForSaveKey(m_currentHostSaveStateKey);
+        m_localInventoryDirtySaveKey = m_currentHostSaveStateKey;
+    }
+    m_localInventoryDirty = true;
+    ++m_localInventoryDirtyRevision;
+    if (m_localInventoryDirtyRevision == 0)
+        m_localInventoryDirtyRevision = 1;
+    m_localInventoryJournalAccumulator = 0.0f;
+    if (reason && reason[0])
+        m_lastPlayerSidecarEvent = "local inventory dirty: " + std::string(reason);
+}
+
 bool ModMain::SaveLocalPlayerSidecar(const char* reason)
 {
     if (!m_enablePlayerSidecar)
@@ -2534,13 +2960,18 @@ bool ModMain::SaveLocalPlayerSidecar(const char* reason)
         return false;
     }
 
+    const bool recoveryJournalCapture =
+        m_clientRecoveryJournalPending &&
+        IsLocalInventoryDirtyForSaveKey(m_currentHostSaveStateKey) &&
+        reason && std::string_view(reason).find("recovery journal") != std::string_view::npos;
     if (m_networkMode == CoopNetworkMode::Client &&
         (m_pendingPlayerSidecarInventoryRestore ||
             m_pendingPlayerSidecarChipsetRestore ||
             m_playerSidecarInventoryPending > 0 ||
             m_playerSidecarChipsetsPending > 0 ||
             m_pendingReceivedPlayerStateApply ||
-            m_clientAwaitingHostPlayerState))
+            m_clientAwaitingHostPlayerState) &&
+        !recoveryJournalCapture)
     {
         ++m_playerSidecarFailCount;
         m_lastPlayerSidecarEvent = "save skipped: host player state restore pending";
@@ -4489,6 +4920,7 @@ bool ModMain::DebugClearLocalInventory(std::string& detail)
         return false;
     }
 
+    MarkLocalInventoryDirty("debug inventory clear");
     ++m_debugInventoryClearCount;
     m_lastDebugInventoryEvent =
         std::string(nativeCleared ? "cleared local inventory" : "cleared local inventory via storage fallback") +
@@ -4627,6 +5059,45 @@ void ModMain::TickPlayerSidecar(float frameTime)
 {
     if (!m_enablePlayerSidecar)
         return;
+
+    if (m_networkMode == CoopNetworkMode::Client &&
+        !m_currentHostSaveStateKey.empty() &&
+        m_currentHostSaveStateKey != "unknown_save")
+    {
+        ReconcileLocalInventoryDirtyForSaveKey(m_currentHostSaveStateKey);
+    }
+
+    if (m_networkMode == CoopNetworkMode::Client &&
+        !m_currentHostSaveStateKey.empty() &&
+        IsLocalInventoryDirtyForSaveKey(m_currentHostSaveStateKey) &&
+        !m_saveLoadGuardActive &&
+        !m_playerStateTransferSending &&
+        IsGameReady())
+    {
+        m_localInventoryJournalAccumulator += std::max(0.0f, frameTime);
+        if (m_localInventoryJournalAccumulator >= 0.5f)
+        {
+            const uint64_t capturedRevision = m_localInventoryDirtyRevision;
+            m_localInventoryJournalAccumulator = 0.0f;
+            const char* reason = m_clientRecoveryJournalPending
+                ? "recovery journal: debounced local inventory mutation"
+                : "debounced local inventory mutation";
+            if (SaveLocalPlayerSidecar(reason) &&
+                WriteLocalPlayerRecoveryJournal(reason) &&
+                capturedRevision == m_localInventoryDirtyRevision)
+            {
+                m_localInventoryDirty = false;
+                m_localInventoryDirtySaveKey.clear();
+                if (m_clientRecoveryJournalPending)
+                    RecoverLocalPlayerRecoveryJournal("refreshed recovery journal");
+            }
+        }
+    }
+    else if (!m_localInventoryDirty ||
+        !IsLocalInventoryDirtyForSaveKey(m_currentHostSaveStateKey))
+    {
+        m_localInventoryJournalAccumulator = 0.0f;
+    }
 
     if (m_pendingPlayerSidecarInventoryRestore)
     {

--- a/CoopPrototype/Src/ModMain.cpp
+++ b/CoopPrototype/Src/ModMain.cpp
@@ -19310,7 +19310,11 @@ static bool CArkItem_PickUp_Hook(CArkItem* item, const unsigned pickerId, bool s
 
     const bool result = s_hookCArkItemPickUp.InvokeOrig(item, pickerId, scaleOnLerp);
     if (gMod)
+    {
         gMod->OnNativeSharedItemPicked(itemEntityId, pickerId, result, "CArkItem::PickUp");
+        if (result)
+            gMod->CaptureLocalPlayerPickupRecovery(pickerId, "CArkItem::PickUp");
+    }
     return result;
 }
 

--- a/CoopPrototype/Src/ModMain.cpp
+++ b/CoopPrototype/Src/ModMain.cpp
@@ -32,6 +32,7 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <Xinput.h>
+#include <Windows.h>
 
 #ifdef min
 #undef min
@@ -105,6 +106,7 @@
 #include <Prey/CrySystem/ISystem.h>
 #include <Prey/CrySystem/ITimer.h>
 #include <Prey/CryGame/Game.h>
+#include <Prey/GameDll/GameStartup.h>
 #include <Prey/Ark/ArkGameStateCondition.h>
 #include <Prey/GameDll/ark/ArkFactionManager.h>
 #include <Prey/GameDll/ark/ArkHealthExtension.h>
@@ -3530,6 +3532,78 @@ bool ValidatePlayerStateIntegrityFile(
     if (outReason)
         *outReason = "hash ok";
     return true;
+}
+
+struct RecoveryStateMetadata
+{
+    uint64_t accountToken = 0;
+    uint64_t revision = 0;
+    std::string saveKey;
+};
+
+bool ReadRecoveryStateMetadata(
+    const std::filesystem::path& path,
+    RecoveryStateMetadata& metadata)
+{
+    metadata = {};
+    bool hasHash = false;
+    std::string reason;
+    if (!ValidatePlayerStateIntegrityFile(path, nullptr, &hasHash, &reason) || !hasHash)
+        return false;
+
+    std::ifstream input(path, std::ios::binary);
+    if (!input)
+        return false;
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    if (!input.good() && !input.eof())
+        return false;
+    const std::string text = buffer.str();
+    const size_t firstLineEnd = text.find('\n');
+    if (firstLineEnd == std::string::npos)
+        return false;
+    std::istringstream payload(text.substr(firstLineEnd + 1));
+    payload.imbue(std::locale::classic());
+    bool accountPresent = false;
+    bool revisionPresent = false;
+    bool saveKeyPresent = false;
+    std::string line;
+    while (std::getline(payload, line))
+    {
+        if (line.rfind("recoveryAccount=", 0) == 0)
+        {
+            const std::string value = line.substr(std::strlen("recoveryAccount="));
+            if (value.empty() || value.size() > 16)
+                return false;
+            metadata.accountToken = 0;
+            for (const char ch : value)
+            {
+                metadata.accountToken <<= 4;
+                if (ch >= '0' && ch <= '9')
+                    metadata.accountToken |= static_cast<uint64_t>(ch - '0');
+                else if (ch >= 'a' && ch <= 'f')
+                    metadata.accountToken |= static_cast<uint64_t>(10 + ch - 'a');
+                else if (ch >= 'A' && ch <= 'F')
+                    metadata.accountToken |= static_cast<uint64_t>(10 + ch - 'A');
+                else
+                    return false;
+            }
+            accountPresent = metadata.accountToken != 0;
+        }
+        else if (line.rfind("recoverySaveKey=", 0) == 0)
+        {
+            metadata.saveKey = line.substr(std::strlen("recoverySaveKey="));
+            saveKeyPresent = !metadata.saveKey.empty();
+        }
+        else if (line.rfind("recoveryRevision=", 0) == 0)
+        {
+            std::istringstream revision(line.substr(std::strlen("recoveryRevision=")));
+            revision.imbue(std::locale::classic());
+            revision >> metadata.revision;
+            revisionPresent = !revision.fail() && metadata.revision != 0;
+        }
+    }
+    return accountPresent && saveKeyPresent && revisionPresent;
 }
 
 bool WriteTextFileWithIntegrityHash(const std::filesystem::path& path, const std::string& payload)
@@ -7606,6 +7680,7 @@ static auto s_hookCryActionSaveGame = CCryAction::FSaveGame.MakeHook();
 static auto s_hookCryActionLoadGame = CCryAction::FLoadGame.MakeHook();
 static auto s_hookCryActionNotifySaveGame = CCryAction::FNotifyGameFrameworkListenersOv1.MakeHook();
 static auto s_hookCryActionNotifyLoadGame = CCryAction::FNotifyGameFrameworkListenersOv0.MakeHook();
+static auto s_hookCGameStartupWndProcHndl = CGameStartup::FWndProcHndl.MakeHook();
 static auto s_hookArkSignalManagerSendPackage = ArkSignalSystem::Manager::FSendPackage.MakeHook();
 static auto s_hookArkSignalManagerSendToReceiver = ArkSignalSystem::Manager::FSendToReceiver.MakeHook();
 static auto s_hookArkPlayerTakeDamage = ArkPlayer::FTakeDamage.MakeHook();
@@ -19248,9 +19323,20 @@ static void CArkItem_ResetCount_Hook(CArkItem* item, int count)
         CoopPtrHygiene::LogPtrWith("item_resetcount", item, extra);
         CoopPtrHygiene::CheckAbove32("item_resetcount", item);
     }
+    unsigned ownerIdBefore = 0;
+    if (item)
+    {
+        // ResetCount(0) may detach the item before the post-hook runs, so
+        // retain the ownership identity while the native object is intact.
+        TryGuardedCall(
+            "CArkItem ResetCount owner before",
+            [item]() { return item->m_ownerId; },
+            ownerIdBefore,
+            nullptr);
+    }
     s_hookCArkItemResetCount.InvokeOrig(item, count);
     if (gMod)
-        gMod->OnArkItemResetCountHook(item, count);
+        gMod->OnArkItemResetCountHook(item, count, ownerIdBefore);
 }
 
 static void CArkItem_NotifyPlayerAcquired_Hook(const CArkItem* item, int count)
@@ -30954,6 +31040,127 @@ void ModMain::OnCoopRenderEndFrame()
     DrawCoopHudOverlayPreRender();
 }
 
+static int64_t CGameStartup_WndProcHndl_Hook(
+    HWND hWnd,
+    unsigned message,
+    uint64_t wParam,
+    int64_t lParam)
+{
+    if (gMod && gMod->HandleNativeWindowMessage(
+            reinterpret_cast<std::uintptr_t>(hWnd),
+            message,
+            wParam,
+            lParam))
+    {
+        // Returning a handled result prevents CGameStartup from beginning
+        // teardown while the client player-state flush is in flight.
+        return 1;
+    }
+
+    return s_hookCGameStartupWndProcHndl.InvokeOrig(hWnd, message, wParam, lParam);
+}
+
+bool ModMain::HandleNativeWindowMessage(
+    std::uintptr_t windowHandle,
+    unsigned message,
+    uint64_t wParam,
+    std::int64_t lParam)
+{
+    const bool isSystemClose =
+        message == WM_SYSCOMMAND && (wParam & 0xFFF0u) == SC_CLOSE;
+    const bool isClose = message == WM_CLOSE || isSystemClose;
+    if (!isClose)
+        return false;
+
+    if (m_nativeWindowCloseReentry)
+    {
+        // This is the close posted after the asynchronous flush completed.
+        // Consume the bypass exactly once, then let the game's original
+        // handler perform normal process teardown.
+        if (windowHandle != m_nativeWindowCloseHandle)
+            return false;
+
+        m_nativeWindowCloseReentry = false;
+        m_nativeWindowCloseHandle = 0;
+        m_nativeWindowCloseMessage = 0;
+        m_nativeWindowCloseWParam = 0;
+        m_nativeWindowCloseLParam = 0;
+        return false;
+    }
+
+    const bool connectedClient =
+        m_networkMode == CoopNetworkMode::Client &&
+        m_socket != kInvalidNetworkSocket &&
+        m_hasRemoteSession &&
+        m_sessionGameplayReady;
+    const bool hasPendingInventoryState =
+        IsLocalInventoryDirtyForSaveKey(m_currentHostSaveStateKey) ||
+        m_pendingPlayerSidecarSave ||
+        HasValidPlayerSidecarRecoveryJournal();
+    if (!connectedClient || !hasPendingInventoryState)
+        return false;
+
+    // A close from another native window must not replace the HWND whose
+    // close is currently being deferred. Leave unrelated windows to their
+    // original handler instead of consuming their close messages.
+    if (m_nativeWindowCloseDeferred)
+        return windowHandle == m_nativeWindowCloseHandle;
+
+    m_nativeWindowCloseHandle = windowHandle;
+    m_nativeWindowCloseMessage = message;
+    m_nativeWindowCloseWParam = wParam;
+    m_nativeWindowCloseLParam = lParam;
+    if (!m_nativeWindowCloseDeferred)
+    {
+        m_nativeWindowCloseDeferred = true;
+        QueueCoopHudFeedback(
+            "SAVING MULTIPLAYER INVENTORY...",
+            kClientDisconnectPlayerStateFlushTimeoutSeconds + 0.5f);
+        LogCoop("native window close deferred for multiplayer inventory flush");
+    }
+    return true;
+}
+
+void ModMain::ResumeDeferredNativeWindowClose()
+{
+    if (!m_nativeWindowCloseDeferred)
+        return;
+
+    if (m_nativeWindowCloseHandle == 0)
+    {
+        m_nativeWindowCloseDeferred = false;
+        m_nativeWindowCloseReentry = false;
+        m_nativeWindowCloseHandle = 0;
+        m_nativeWindowCloseMessage = 0;
+        m_nativeWindowCloseWParam = 0;
+        m_nativeWindowCloseLParam = 0;
+        return;
+    }
+
+    const HWND window = reinterpret_cast<HWND>(m_nativeWindowCloseHandle);
+    const unsigned message = m_nativeWindowCloseMessage == 0
+        ? WM_CLOSE
+        : m_nativeWindowCloseMessage;
+    const uint64_t wParam = m_nativeWindowCloseWParam;
+    const int64_t lParam = m_nativeWindowCloseLParam;
+    m_nativeWindowCloseDeferred = false;
+    m_nativeWindowCloseReentry = true;
+    if (!PostMessageW(window, message, static_cast<WPARAM>(wParam), static_cast<LPARAM>(lParam)))
+    {
+        const DWORD error = GetLastError();
+        m_nativeWindowCloseReentry = false;
+        m_nativeWindowCloseHandle = 0;
+        m_nativeWindowCloseMessage = 0;
+        m_nativeWindowCloseWParam = 0;
+        m_nativeWindowCloseLParam = 0;
+        LogCoop("native window close repost failed error=" + std::to_string(error));
+        // The original close was consumed by the hook. If reposting fails,
+        // invoke the original handler now rather than leaving the app in a
+        // permanently deferred-close state.
+        s_hookCGameStartupWndProcHndl.InvokeOrig(window, message, wParam, lParam);
+    }
+}
+
 void ModMain::InitHooks()
 {
     const bool disableNativeInventoryHooks = EnvFlagEnabled("COOP_DISABLE_NATIVE_INVENTORY_HOOKS");
@@ -30986,6 +31193,7 @@ void ModMain::InitHooks()
     s_hookCryActionLoadGame.SetHookFunc(&CryAction_LoadGame_Hook);
     s_hookCryActionNotifySaveGame.SetHookFunc(&CryAction_NotifySaveGame_Hook);
     s_hookCryActionNotifyLoadGame.SetHookFunc(&CryAction_NotifyLoadGame_Hook);
+    s_hookCGameStartupWndProcHndl.SetHookFunc(&CGameStartup_WndProcHndl_Hook);
     s_hookArkNpcOnHit.SetHookFunc(&ArkNpc_OnHit_Hook);
     s_hookArkNpcPushFear.SetHookFunc(&ArkNpc_PushFear_ProxyGuard_Hook);
     s_hookArkNpcPerformCombatReaction.SetHookFunc(&ArkNpc_PerformCombatReaction_ProxyGuard_Hook);
@@ -34970,6 +35178,16 @@ void ModMain::MainUpdate(unsigned updateFlags)
         }
         else if (leavingMode == CoopNetworkMode::Host)
             StopNetwork();
+    }
+    if (m_nativeWindowCloseDeferred && !m_clientDisconnectFlushPending)
+    {
+        // WndProc must stay non-blocking. Start the bounded flush from the
+        // normal update thread, where the sidecar capture is safe to perform.
+        if (!BeginClientIntentionalDisconnect("native window close"))
+        {
+            LogCoop("native window close flush skipped: client session no longer ready");
+            ResumeDeferredNativeWindowClose();
+        }
     }
     TickClientIntentionalDisconnect(frameTime);
     if (m_multiplayerKickRequestedToken != 0)
@@ -51319,8 +51537,12 @@ void ModMain::ResetPlayerStateTransferState(const char* lastEvent)
     const uint32_t preservedDisconnectTransferId = m_clientDisconnectFlushTransferId;
     const uint32_t preservedDisconnectChecksum = m_clientDisconnectFlushChecksum;
     const float preservedDisconnectRemainingSeconds = m_clientDisconnectFlushRemainingSeconds;
+    const float preservedDisconnectCaptureRetrySeconds = m_clientDisconnectFlushCaptureRetrySeconds;
+    const std::chrono::steady_clock::time_point preservedDisconnectDeadline = m_clientDisconnectFlushDeadline;
     const std::string preservedDisconnectReason = m_clientDisconnectFlushReason;
     const std::string preservedDisconnectSaveKey = m_clientDisconnectFlushSaveKey;
+    const std::string preservedDisconnectJournalSourcePath = m_clientDisconnectFlushJournalSourcePath;
+    const uint64_t preservedDisconnectJournalRevision = m_clientDisconnectFlushJournalRevision;
 
     if (!preserveClientDisconnectFlush && !m_clientDisconnectTransferSourcePath.empty())
     {
@@ -51377,12 +51599,24 @@ void ModMain::ResetPlayerStateTransferState(const char* lastEvent)
     m_clientDisconnectFlushRemainingSeconds = preserveClientDisconnectFlush
         ? preservedDisconnectRemainingSeconds
         : 0.0f;
+    m_clientDisconnectFlushCaptureRetrySeconds = preserveClientDisconnectFlush
+        ? preservedDisconnectCaptureRetrySeconds
+        : 0.0f;
+    m_clientDisconnectFlushDeadline = preserveClientDisconnectFlush
+        ? preservedDisconnectDeadline
+        : std::chrono::steady_clock::time_point();
     m_clientDisconnectFlushReason = preserveClientDisconnectFlush
         ? preservedDisconnectReason
         : std::string();
     m_clientDisconnectFlushSaveKey = preserveClientDisconnectFlush
         ? preservedDisconnectSaveKey
         : std::string();
+    m_clientDisconnectFlushJournalSourcePath = preserveClientDisconnectFlush
+        ? preservedDisconnectJournalSourcePath
+        : std::string();
+    m_clientDisconnectFlushJournalRevision = preserveClientDisconnectFlush
+        ? preservedDisconnectJournalRevision
+        : 0;
     m_clientPlayerSnapshotForUploadPending = false;
     m_clientPlayerSnapshotCooldownSeconds = 0.0f;
     m_clientPlayerSnapshotForUploadWaitSeconds = 0.0f;
@@ -51395,8 +51629,20 @@ void ModMain::ResetPlayerStateTransferState(const char* lastEvent)
     m_pendingHostPlayerStateSend = false;
     m_pendingClientPlayerStateUpload = false;
     m_pendingReceivedPlayerStateApply = false;
+    m_pendingHostAuthoritativePlayerStateReceivePath.clear();
     m_pendingNativePlayerStateOverrideValid = false;
     m_pendingNativePlayerStateOverride = PlayerSidecarState();
+    // A network/reset boundary cancels only in-flight recovery transport. The
+    // durable journal is intentionally left on disk for the next exact host
+    // identity handshake.
+    m_clientRecoveryJournalPending = false;
+    m_clientRecoveryJournalAwaitingStoredAck = false;
+    m_clientRecoveryJournalStoredAckReceived = false;
+    m_clientRecoveryJournalTransferId = 0;
+    m_clientRecoveryJournalChecksum = 0;
+    m_clientRecoveryJournalRevision = 0;
+    m_clientRecoveryJournalSourcePath.clear();
+    m_clientRecoveryJournalSaveKey.clear();
     m_clientAwaitingHostPlayerState = false;
     m_hostPlayerStatePreloadSent = false;
     m_receivedPlayerStateInventoryPreparedForNativeLoad = false;
@@ -52447,6 +52693,17 @@ void ModMain::StartClient()
 
 void ModMain::StopNetwork()
 {
+    const bool preserveClientInventoryRecovery =
+        m_networkMode == CoopNetworkMode::Client &&
+        (m_clientDisconnectFlushPending ||
+            IsLocalInventoryDirtyForSaveKey(m_currentHostSaveStateKey));
+
+    // A peer-loss teardown can bypass the intentional-disconnect tick. The
+    // original close message was already consumed, so always put it back on
+    // the window queue before clearing session state.
+    if (m_nativeWindowCloseDeferred)
+        ResumeDeferredNativeWindowClose();
+
     if (m_clientDisconnectFlushPending)
     {
         // StopNetwork is the connection-loss/replacement path. It must not
@@ -52460,8 +52717,12 @@ void ModMain::StopNetwork()
         m_clientDisconnectFlushTransferId = 0;
         m_clientDisconnectFlushChecksum = 0;
         m_clientDisconnectFlushRemainingSeconds = 0.0f;
+        m_clientDisconnectFlushCaptureRetrySeconds = 0.0f;
+        m_clientDisconnectFlushDeadline = std::chrono::steady_clock::time_point();
         m_clientDisconnectFlushReason.clear();
         m_clientDisconnectFlushSaveKey.clear();
+        m_clientDisconnectFlushJournalSourcePath.clear();
+        m_clientDisconnectFlushJournalRevision = 0;
     }
     m_debugPlayerFollowEnemyNetId = 0;
     m_pendingDebugEnemyAbilityNetId = 0;
@@ -52523,7 +52784,9 @@ void ModMain::StopNetwork()
         }
     }
 
-    SaveLocalPlayerSidecar("network stop");
+    const bool savedNetworkStopSidecar = SaveLocalPlayerSidecar("network stop");
+    if (preserveClientInventoryRecovery && savedNetworkStopSidecar)
+        WriteLocalPlayerRecoveryJournal("network stop recovery fallback");
     ClearJoinOverlayState("network stop");
     ReleaseLocalPlayerDownedAttentionState();
     ReleaseLocalDownedControls();
@@ -52853,6 +53116,16 @@ void ModMain::StopNetwork()
     m_sentMimicDeadState = false;
     m_mimicHealthAvailable = false;
     m_lastMimicDamage = 0.0f;
+
+    // Network shutdown invalidates any HWND captured from the old session.
+    // Never carry a deferred native close or its reentry bypass into a new
+    // session.
+    m_nativeWindowCloseDeferred = false;
+    m_nativeWindowCloseReentry = false;
+    m_nativeWindowCloseHandle = 0;
+    m_nativeWindowCloseMessage = 0;
+    m_nativeWindowCloseWParam = 0;
+    m_nativeWindowCloseLParam = 0;
 }
 
 void ModMain::TickNetwork(float frameTime)
@@ -57553,6 +57826,7 @@ void ModMain::SetCurrentHostSaveStateKey(const std::string& saveKey, bool retain
     }
 
     m_currentHostSaveStateKey = saveKey;
+    ReconcileLocalInventoryDirtyForSaveKey(saveKey);
 }
 
 uint64_t ModMain::BuildStoryEventId(uint16_t eventKind, uint64_t targetId, int32_t count, uint16_t flags, uint32_t sequence) const
@@ -68568,6 +68842,17 @@ void ModMain::RemoveRemotePeer(uint64_t accountToken, const char* reason, bool a
     if (it == m_remotePeers.end())
         return;
     const RemotePeerSession peer = it->second;
+
+    // A host save transfer is shared by the active peer context, but its
+    // completion state is still owned by the account it targets. Do not let
+    // a completed transfer for a departed peer block that account's next
+    // ClientNeedsHostWorld request (or affect another connected peer).
+    if (m_networkMode == CoopNetworkMode::Host &&
+        m_saveTransferAccountToken == accountToken)
+    {
+        ResetSaveTransferState("remote peer removed; save transfer reset");
+    }
+
     std::vector<EntityId> reclaimedTurretEntities;
 
     uint32_t releasedEnemyLeases = 0;
@@ -73674,7 +73959,7 @@ bool ModMain::BeginClientPlayerStateUpload(const char* reason, const std::string
     return started;
 }
 
-bool ModMain::BeginClientIntentionalDisconnect(const char* reason)
+bool ModMain::BeginClientIntentionalDisconnect(const char* reason, bool captureImmediately)
 {
     if (m_networkMode != CoopNetworkMode::Client ||
         m_socket == kInvalidNetworkSocket ||
@@ -73697,26 +73982,90 @@ bool ModMain::BeginClientIntentionalDisconnect(const char* reason)
     m_clientDisconnectFlushTransferId = 0;
     m_clientDisconnectFlushChecksum = 0;
     m_clientDisconnectFlushRemainingSeconds = kClientDisconnectPlayerStateFlushTimeoutSeconds;
+    m_clientDisconnectFlushCaptureRetrySeconds = 0.0f;
+    m_clientDisconnectFlushDeadline =
+        std::chrono::steady_clock::now() +
+        std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+            std::chrono::duration<float>(kClientDisconnectPlayerStateFlushTimeoutSeconds));
     m_clientDisconnectFlushReason = reason && reason[0] ? reason : "intentional client disconnect";
     m_clientDisconnectFlushSaveKey = !m_currentHostSaveStateKey.empty()
         ? m_currentHostSaveStateKey
         : BuildHostSaveStateKey(m_lastSaveLoadPath);
+    m_clientDisconnectFlushJournalSourcePath.clear();
+    m_clientDisconnectFlushJournalRevision = 0;
     m_clientDisconnectTransferSourcePath.clear();
+    m_clientDisconnectFlushCaptureAttempted = false;
 
+    if (captureImmediately)
+        CaptureClientDisconnectSnapshot();
+    return true;
+}
+
+bool ModMain::CaptureClientDisconnectSnapshot()
+{
+    if (m_clientDisconnectFlushCaptureAttempted)
+        return !m_clientDisconnectTransferSourcePath.empty();
+
+    m_clientDisconnectFlushCaptureAttempted = true;
     m_lastPlayerStateTransferEvent =
         "intentional disconnect: capturing live player sidecar saveKey=" +
         (m_clientDisconnectFlushSaveKey.empty() ? std::string("-") : m_clientDisconnectFlushSaveKey);
     LogCoop(m_lastPlayerStateTransferEvent);
 
-    if (!IsGameReady() || !SaveLocalPlayerSidecar("intentional disconnect live sidecar"))
+    const uint64_t capturedDirtyRevision = m_localInventoryDirtyRevision;
+    // Always recapture the live sidecar before creating a journal. A valid
+    // journal is durable fallback data, not permission to reuse an older
+    // snapshot while the live player is available.
+    bool liveCaptureSucceeded = false;
+    if (!m_saveLoadGuardActive &&
+        !m_arkLevelTransitionLoadActive &&
+        IsGameReady() &&
+        SaveLocalPlayerSidecar("intentional disconnect live sidecar"))
+    {
+        liveCaptureSucceeded = true;
+    }
+    else
     {
         // Keep the five-second bounded state alive. A sidecar written by an
         // earlier save remains the local fallback if the live capture is not
         // available during a transition or native save guard.
+        if (HasValidPlayerSidecarRecoveryJournal())
+        {
+            m_lastPlayerStateTransferEvent =
+                "intentional disconnect: live capture unavailable; using existing recovery journal";
+            LogCoop(m_lastPlayerStateTransferEvent);
+        }
+        else
+        {
+            m_lastPlayerStateTransferEvent =
+                "intentional disconnect: live sidecar capture unavailable; local fallback armed";
+            LogCoop(m_lastPlayerStateTransferEvent);
+            m_clientDisconnectFlushCaptureAttempted = false;
+            m_clientDisconnectFlushCaptureRetrySeconds = 0.25f;
+            return false;
+        }
+    }
+
+    // Never fall back to an older journal after a successful fresh capture
+    // whose journal write failed. The immutable live sidecar is newer.
+    const bool journalWritten = liveCaptureSucceeded &&
+        WriteLocalPlayerRecoveryJournal("intentional disconnect");
+    if (liveCaptureSucceeded && !journalWritten)
+    {
+        // Keep the live snapshot from being shadowed by an older journal on a
+        // later reconnect. The dirty bit makes the next exact host identity
+        // retry the journal write before any recovery upload can start.
+        m_localInventoryDirty = true;
+        m_localInventoryDirtySaveKey = m_clientDisconnectFlushSaveKey;
+        m_localInventoryJournalAccumulator = 0.0f;
         m_lastPlayerStateTransferEvent =
-            "intentional disconnect: live sidecar capture unavailable; local fallback armed";
+            "intentional disconnect: recovery journal write unavailable; local fallback armed";
         LogCoop(m_lastPlayerStateTransferEvent);
-        return true;
+    }
+    else if (journalWritten && capturedDirtyRevision == m_localInventoryDirtyRevision)
+    {
+        m_localInventoryDirty = false;
+        m_localInventoryDirtySaveKey.clear();
     }
 
     const uint32_t transferId =
@@ -73731,11 +74080,37 @@ bool ModMain::BeginClientIntentionalDisconnect(const char* reason)
         m_lastPlayerStateTransferEvent =
             "intentional disconnect: immutable sidecar snapshot path unavailable; local fallback armed";
         LogCoop(m_lastPlayerStateTransferEvent);
-        return true;
+        m_clientDisconnectFlushCaptureAttempted = false;
+        m_clientDisconnectFlushCaptureRetrySeconds = 0.25f;
+        return false;
     }
 
     std::error_code error;
-    const std::filesystem::path source = CoopFilesystem::FromUtf8(GetPlayerSidecarPath());
+    const std::string journalPath = GetPlayerSidecarRecoveryJournalPath();
+    // Prefer the freshly captured canonical sidecar if writing the recovery
+    // journal failed. Never fall back to an older journal in that case.
+    const std::string sourcePathString = journalWritten
+        ? journalPath
+        : (liveCaptureSucceeded ? GetPlayerSidecarPath() :
+            (HasValidPlayerSidecarRecoveryJournal() ? journalPath : GetPlayerSidecarPath()));
+    if (journalWritten)
+    {
+        m_clientDisconnectFlushJournalSourcePath = journalPath;
+        m_clientDisconnectFlushJournalRevision = GetPlayerSidecarRecoveryJournalRevision();
+    }
+    else if (!liveCaptureSucceeded && !journalPath.empty())
+    {
+        // The immutable source is the durable journal when live capture was
+        // unavailable. Track its exact revision so only this acknowledged
+        // journal can be cleared below.
+        const uint64_t journalRevision = GetPlayerSidecarRecoveryJournalRevision();
+        if (journalRevision != 0)
+        {
+            m_clientDisconnectFlushJournalSourcePath = journalPath;
+            m_clientDisconnectFlushJournalRevision = journalRevision;
+        }
+    }
+    const std::filesystem::path source = CoopFilesystem::FromUtf8(sourcePathString);
     const std::filesystem::path snapshot = CoopFilesystem::FromUtf8(sourcePath);
     std::filesystem::create_directories(snapshot.parent_path(), error);
     if (!error)
@@ -73750,8 +74125,10 @@ bool ModMain::BeginClientIntentionalDisconnect(const char* reason)
     {
         m_lastPlayerStateTransferEvent =
             "intentional disconnect: immutable sidecar snapshot failed; local fallback armed";
+        m_clientDisconnectFlushCaptureAttempted = false;
+        m_clientDisconnectFlushCaptureRetrySeconds = 0.25f;
         LogCoop(m_lastPlayerStateTransferEvent);
-        return true;
+        return false;
     }
 
     // PlayerStateTransfer re-opens its source for every chunk. Pointing it at
@@ -73760,7 +74137,9 @@ bool ModMain::BeginClientIntentionalDisconnect(const char* reason)
     m_clientDisconnectTransferSourcePath = sourcePath;
     m_clientDisconnectFlushTransferId = transferId;
     m_lastPlayerStateTransferEvent =
-        "intentional disconnect: immutable live sidecar snapshot captured";
+        "intentional disconnect: immutable " +
+        (sourcePathString == journalPath ? std::string("recovery journal") : std::string("live sidecar")) +
+        " snapshot captured";
     LogCoop(m_lastPlayerStateTransferEvent);
     return true;
 }
@@ -73771,26 +74150,62 @@ void ModMain::TickClientIntentionalDisconnect(float frameTime)
         return;
 
     const bool transportPaused = m_saveLoadGuardActive || m_arkLevelTransitionLoadActive;
-    if (!transportPaused)
+    const auto now = std::chrono::steady_clock::now();
+    if (m_clientDisconnectFlushDeadline == std::chrono::steady_clock::time_point())
     {
-        m_clientDisconnectFlushRemainingSeconds = std::max(
-            0.0f,
-            m_clientDisconnectFlushRemainingSeconds - std::max(0.0f, frameTime));
+        m_clientDisconnectFlushDeadline = now +
+            std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+                std::chrono::duration<float>(m_clientDisconnectFlushRemainingSeconds));
     }
+    const float wallRemaining = std::max(
+        0.0f,
+        std::chrono::duration<float>(m_clientDisconnectFlushDeadline - now).count());
+    m_clientDisconnectFlushRemainingSeconds = wallRemaining;
+
+    m_clientDisconnectFlushCaptureRetrySeconds = std::max(
+        0.0f,
+        m_clientDisconnectFlushCaptureRetrySeconds - std::max(0.0f, frameTime));
 
     if (m_clientDisconnectFlushStoredAckReceived)
     {
         const std::string reason = m_clientDisconnectFlushReason.empty()
             ? std::string("intentional disconnect")
             : m_clientDisconnectFlushReason;
+        const bool resumeNativeClose = m_nativeWindowCloseDeferred;
+        if (!m_clientDisconnectFlushJournalSourcePath.empty())
+        {
+            ClearLocalPlayerRecoveryJournal(
+                m_clientDisconnectFlushJournalSourcePath,
+                GetLocalAccountToken(),
+                m_clientDisconnectFlushSaveKey,
+                m_clientDisconnectFlushJournalRevision,
+                "host StoredAck");
+        }
         m_clientDisconnectFlushPending = false;
         m_clientDisconnectFlushAwaitingStoredAck = false;
         m_clientDisconnectFlushStoredAckReceived = false;
+        m_clientDisconnectFlushCaptureAttempted = false;
+        m_clientDisconnectFlushCaptureRetrySeconds = 0.0f;
+        m_clientDisconnectFlushDeadline = std::chrono::steady_clock::time_point();
+        m_clientDisconnectFlushJournalSourcePath.clear();
+        m_clientDisconnectFlushJournalRevision = 0;
         m_lastPlayerStateTransferEvent =
             "intentional disconnect: host stored player state; disconnecting";
         LogCoop(m_lastPlayerStateTransferEvent);
+        if (resumeNativeClose)
+            ResumeDeferredNativeWindowClose();
         DisconnectRemotePeer((reason + "; player state stored").c_str());
         return;
+    }
+
+    if (!m_clientDisconnectFlushAwaitingStoredAck &&
+        m_clientDisconnectTransferSourcePath.empty() &&
+        m_clientDisconnectFlushCaptureRetrySeconds <= 0.0f)
+    {
+        // Retry the snapshot from the normal update tick. Capture itself
+        // refuses to enter native save state while a load guard is active;
+        // the wall-clock deadline below still advances during that guard.
+        CaptureClientDisconnectSnapshot();
     }
 
     if (!m_clientDisconnectFlushAwaitingStoredAck &&
@@ -73821,21 +74236,28 @@ void ModMain::TickClientIntentionalDisconnect(float frameTime)
     const std::string reason = m_clientDisconnectFlushReason.empty()
         ? std::string("intentional disconnect")
         : m_clientDisconnectFlushReason;
-    if (m_clientDisconnectTransferSourcePath.empty() &&
-        IsGameReady() &&
+    if (IsGameReady() &&
         !m_saveLoadGuardActive &&
         !m_arkLevelTransitionLoadActive)
     {
         // Preserve the best local recovery point even when the initial live
         // capture was blocked by a transient native load/save guard.
-        SaveLocalPlayerSidecar("intentional disconnect fallback sidecar");
+        if (SaveLocalPlayerSidecar("intentional disconnect fallback sidecar"))
+            WriteLocalPlayerRecoveryJournal("intentional disconnect timeout fallback");
     }
     m_clientDisconnectFlushPending = false;
     m_clientDisconnectFlushAwaitingStoredAck = false;
     m_clientDisconnectFlushStoredAckReceived = false;
+    m_clientDisconnectFlushCaptureAttempted = false;
+    m_clientDisconnectFlushCaptureRetrySeconds = 0.0f;
+    m_clientDisconnectFlushDeadline = std::chrono::steady_clock::time_point();
+    m_clientDisconnectFlushJournalSourcePath.clear();
+    m_clientDisconnectFlushJournalRevision = 0;
     m_lastPlayerStateTransferEvent =
         "intentional disconnect: stored ack timeout; using local sidecar fallback";
     LogCoop(m_lastPlayerStateTransferEvent);
+    if (m_nativeWindowCloseDeferred)
+        ResumeDeferredNativeWindowClose();
     DisconnectRemotePeer((reason + "; player state flush timeout").c_str());
 }
 
@@ -74098,6 +74520,7 @@ bool ModMain::EnforceClientPlayerStateApplyInvariant(const char* reason)
         return false;
 
     m_pendingReceivedPlayerStateApply = false;
+    m_pendingHostAuthoritativePlayerStateReceivePath.clear();
     m_pendingNativePlayerStateOverrideValid = false;
     m_pendingNativePlayerStateOverride = PlayerSidecarState();
     m_clientAwaitingHostPlayerState = false;
@@ -74143,9 +74566,18 @@ bool ModMain::PrepareReceivedPlayerStateForHostLoad(const char* reason)
         return false;
 
     PlayerSidecarState state;
-    if (!LoadPlayerSidecarFromPath(m_playerStateTransferReceivePath, state))
+    const bool useRecoveryJournal =
+        m_clientRecoveryJournalPending &&
+        !m_clientRecoveryJournalSourcePath.empty() &&
+        m_clientRecoveryJournalSaveKey == m_currentHostSaveStateKey;
+    const std::string& sourcePath = useRecoveryJournal
+        ? m_clientRecoveryJournalSourcePath
+        : m_playerStateTransferReceivePath;
+    if (!LoadPlayerSidecarFromPath(sourcePath, state))
     {
-        m_lastPlayerStateTransferEvent = "failed to prepare host player state before load";
+        m_lastPlayerStateTransferEvent = useRecoveryJournal
+            ? "failed to prepare recovery journal before host load"
+            : "failed to prepare host player state before load";
         return false;
     }
 
@@ -74174,7 +74606,7 @@ bool ModMain::PrepareReceivedPlayerStateForHostLoad(const char* reason)
     }
 
     m_lastPlayerStateTransferEvent =
-        "prepared host player state before load inv=" +
+        std::string(useRecoveryJournal ? "prepared recovery player state before load inv=" : "prepared host player state before load inv=") +
         std::to_string(state.hasInventory ? static_cast<int>(state.inventory.size()) : -1) +
         " native=" + std::to_string(state.hasNativeCapture ? 1 : 0) +
         " nativeItems=" + std::to_string(state.nativeCapture.items.size()) +
@@ -74572,6 +75004,14 @@ bool ModMain::TryApplyReceivedPlayerStateTransfer(const char* reason)
     if (!m_pendingReceivedPlayerStateApply)
         return false;
 
+    if (m_clientRecoveryJournalPending)
+    {
+        m_lastPlayerStateTransferEvent =
+            "waiting to apply host player state: recovery journal upload pending";
+        m_receivedPlayerStateApplyDelaySeconds = kHostPlayerStateRetryApplyDelaySeconds;
+        return false;
+    }
+
     if (!IsGameReady())
     {
         m_lastPlayerStateTransferEvent = "waiting to apply host player state: game not ready";
@@ -74599,6 +75039,7 @@ bool ModMain::TryApplyReceivedPlayerStateTransfer(const char* reason)
         }
 
         m_pendingReceivedPlayerStateApply = false;
+        m_pendingHostAuthoritativePlayerStateReceivePath.clear();
         m_pendingNativePlayerStateOverrideValid = false;
         m_pendingNativePlayerStateOverride = PlayerSidecarState();
         m_clientAwaitingHostPlayerState = false;
@@ -74629,11 +75070,17 @@ bool ModMain::TryApplyReceivedPlayerStateTransfer(const char* reason)
     {
         state = m_pendingNativePlayerStateOverride;
     }
-    else if (!LoadPlayerSidecarFromPath(m_playerStateTransferReceivePath, state))
+    else
     {
-        m_lastPlayerStateTransferEvent = "failed to load received player state";
-        m_receivedPlayerStateApplyDelaySeconds = kHostPlayerStateRetryApplyDelaySeconds;
-        return false;
+        const std::string receivePath = !m_playerStateTransferReceivePath.empty()
+            ? m_playerStateTransferReceivePath
+            : m_pendingHostAuthoritativePlayerStateReceivePath;
+        if (!LoadPlayerSidecarFromPath(receivePath, state))
+        {
+            m_lastPlayerStateTransferEvent = "failed to load received player state";
+            m_receivedPlayerStateApplyDelaySeconds = kHostPlayerStateRetryApplyDelaySeconds;
+            return false;
+        }
     }
 
     const std::string currentLevel = NormalizeLevelName(GetCurrentLevelName());
@@ -74675,6 +75122,7 @@ bool ModMain::TryApplyReceivedPlayerStateTransfer(const char* reason)
     }
 
     m_pendingReceivedPlayerStateApply = false;
+    m_pendingHostAuthoritativePlayerStateReceivePath.clear();
     m_pendingNativePlayerStateOverrideValid = false;
     m_pendingNativePlayerStateOverride = PlayerSidecarState();
     m_clientAwaitingHostPlayerState = false;
@@ -74703,6 +75151,146 @@ bool ModMain::TryApplyReceivedPlayerStateTransfer(const char* reason)
 void ModMain::TickPlayerStateTransfer(float frameTime)
 {
     const float clampedFrameTime = std::max(0.0f, frameTime);
+
+    if (m_clientRecoveryJournalStoredAckReceived)
+    {
+        const uint64_t acknowledgedRevision = m_clientRecoveryJournalRevision;
+        const std::string acknowledgedSourcePath = m_clientRecoveryJournalSourcePath;
+        const std::string acknowledgedSaveKey = m_clientRecoveryJournalSaveKey;
+        const bool cleared = ClearLocalPlayerRecoveryJournal(
+            acknowledgedSourcePath,
+            GetLocalAccountToken(),
+            acknowledgedSaveKey,
+            acknowledgedRevision,
+            "host recovery journal StoredAck");
+        RecoveryStateMetadata currentJournal;
+        const bool currentJournalReadable =
+            !acknowledgedSourcePath.empty() &&
+            ReadRecoveryStateMetadata(
+                CoopFilesystem::FromUtf8(acknowledgedSourcePath),
+                currentJournal);
+        const bool newerJournal = currentJournalReadable &&
+            currentJournal.accountToken == GetLocalAccountToken() &&
+            currentJournal.saveKey == acknowledgedSaveKey &&
+            currentJournal.revision > acknowledgedRevision;
+        const bool newerLocalMutation =
+            IsLocalInventoryDirtyForSaveKey(acknowledgedSaveKey) || newerJournal;
+
+        if (newerLocalMutation)
+        {
+            // Keep the join blocked until the latest on-disk snapshot has its
+            // own upload/ack. The old ack is scoped to its immutable source;
+            // it must not clear or apply over a newer local inventory.
+            m_clientRecoveryJournalPending = true;
+            m_clientRecoveryJournalAwaitingStoredAck = false;
+            m_clientRecoveryJournalStoredAckReceived = false;
+            m_clientRecoveryJournalTransferId = 0;
+            m_clientRecoveryJournalChecksum = 0;
+            m_clientRecoveryJournalRevision = 0;
+            m_clientRecoveryJournalSourcePath.clear();
+            m_clientRecoveryJournalSaveKey.clear();
+
+            bool capturedNewerMutation = false;
+            if (IsLocalInventoryDirtyForSaveKey(acknowledgedSaveKey) &&
+                !m_saveLoadGuardActive &&
+                m_currentHostSaveStateKey == acknowledgedSaveKey &&
+                IsGameReady())
+            {
+                const uint64_t capturedRevision = m_localInventoryDirtyRevision;
+                const char* captureReason = "recovery journal: mutation after StoredAck";
+                if (SaveLocalPlayerSidecar(captureReason) &&
+                    WriteLocalPlayerRecoveryJournal(captureReason) &&
+                    capturedRevision == m_localInventoryDirtyRevision)
+                {
+                    m_localInventoryDirty = false;
+                    m_localInventoryDirtySaveKey.clear();
+                    capturedNewerMutation = true;
+                }
+            }
+            // If capture failed, leave the source empty and let the retry path
+            // capture the live mutation. Reusing the just-acked journal would
+            // upload stale state over the newer local mutation.
+            if (!m_localInventoryDirty && (capturedNewerMutation || newerJournal))
+                RecoverLocalPlayerRecoveryJournal("newer local recovery journal");
+        }
+        else
+        {
+            m_clientRecoveryJournalPending = false;
+            m_clientRecoveryJournalAwaitingStoredAck = false;
+            m_clientRecoveryJournalStoredAckReceived = false;
+            m_clientRecoveryJournalTransferId = 0;
+            m_clientRecoveryJournalChecksum = 0;
+            m_clientRecoveryJournalRevision = 0;
+            m_clientRecoveryJournalSourcePath.clear();
+            m_clientRecoveryJournalSaveKey.clear();
+            if (!cleared)
+                m_lastPlayerStateTransferEvent = "recovery journal ack had no matching source; continuing host apply";
+        }
+    }
+
+    if (m_networkMode == CoopNetworkMode::Client &&
+        m_clientRecoveryJournalPending &&
+        m_clientRecoveryJournalSourcePath.empty() &&
+        IsLocalInventoryDirtyForSaveKey(m_currentHostSaveStateKey) &&
+        !m_currentHostSaveStateKey.empty() &&
+        !m_saveLoadGuardActive &&
+        !m_playerStateTransferSending &&
+        !m_playerStateTransferReceiving &&
+        IsGameReady())
+    {
+        const uint64_t capturedRevision = m_localInventoryDirtyRevision;
+        const char* captureReason = "recovery journal: retry newer mutation capture";
+        if (SaveLocalPlayerSidecar(captureReason) &&
+            WriteLocalPlayerRecoveryJournal(captureReason) &&
+            capturedRevision == m_localInventoryDirtyRevision)
+        {
+            m_localInventoryDirty = false;
+            m_localInventoryDirtySaveKey.clear();
+        }
+        RecoverLocalPlayerRecoveryJournal(captureReason);
+    }
+
+    if (m_networkMode == CoopNetworkMode::Client &&
+        m_clientRecoveryJournalPending &&
+        !m_clientRecoveryJournalAwaitingStoredAck &&
+        !m_clientDisconnectFlushPending &&
+        !m_currentHostSaveStateKey.empty() &&
+        m_currentHostSaveStateKey == m_clientRecoveryJournalSaveKey &&
+        !IsLocalInventoryDirtyForSaveKey(m_currentHostSaveStateKey) &&
+        !m_saveLoadGuardActive &&
+        !m_playerStateTransferSending &&
+        !m_playerStateTransferReceiving &&
+        // On the initial join the Host's Start may arrive just after the
+        // save-identity packet. Do not let the recovery upload take over the
+        // shared transfer slot before that Start has been received; the host
+        // transfer remains available for apply after this upload is acked.
+        (!m_clientAwaitingHostPlayerState || m_pendingReceivedPlayerStateApply) &&
+        !m_clientRecoveryJournalSourcePath.empty())
+    {
+        if (m_clientRecoveryJournalTransferId == 0)
+        {
+            m_clientRecoveryJournalTransferId =
+                m_playerStateTransferId == std::numeric_limits<uint32_t>::max()
+                    ? 1u
+                    : m_playerStateTransferId + 1u;
+        }
+        if (StartPlayerStateTransferFromFile(
+                m_clientRecoveryJournalSourcePath,
+                GetLocalUsername(),
+                CoopProtocol::kPlayerStateTransferFlagUploadToHost,
+                m_clientRecoveryJournalTransferId,
+                m_clientRecoveryJournalSaveKey))
+        {
+            m_clientRecoveryJournalAwaitingStoredAck = true;
+            m_clientRecoveryJournalChecksum = m_playerStateTransferChecksum;
+            m_lastPlayerStateTransferEvent =
+                "started recovery journal upload revision=" +
+                std::to_string(m_clientRecoveryJournalRevision) +
+                " saveKey=" + m_clientRecoveryJournalSaveKey;
+            LogCoop(m_lastPlayerStateTransferEvent);
+        }
+    }
+
     if (m_clientPlayerSnapshotCooldownSeconds > 0.0f)
         m_clientPlayerSnapshotCooldownSeconds = std::max(0.0f, m_clientPlayerSnapshotCooldownSeconds - clampedFrameTime);
 
@@ -76174,6 +76762,21 @@ void ModMain::HandlePlayerStateTransfer(const CoopProtocol::PlayerStateTransferP
 
     if (command == CoopProtocol::PlayerStateTransferCommand::StoredAck)
     {
+        if (m_networkMode == CoopNetworkMode::Client &&
+            m_clientRecoveryJournalPending &&
+            m_clientRecoveryJournalAwaitingStoredAck &&
+            packet.transferId == m_clientRecoveryJournalTransferId &&
+            packet.checksum == m_clientRecoveryJournalChecksum &&
+            saveKey == m_clientRecoveryJournalSaveKey)
+        {
+            m_clientRecoveryJournalStoredAckReceived = true;
+            m_lastPlayerStateTransferEvent =
+                "received host recovery journal stored ack transfer=" +
+                std::to_string(packet.transferId) +
+                " revision=" + std::to_string(m_clientRecoveryJournalRevision);
+            LogCoop(m_lastPlayerStateTransferEvent);
+            return;
+        }
         if (m_networkMode != CoopNetworkMode::Client ||
             !m_clientDisconnectFlushPending ||
             !m_clientDisconnectFlushAwaitingStoredAck ||
@@ -76204,6 +76807,7 @@ void ModMain::HandlePlayerStateTransfer(const CoopProtocol::PlayerStateTransferP
         }
 
         SetCurrentHostSaveStateKey(saveKey, true);
+        RecoverLocalPlayerRecoveryJournal("host save identity");
         m_lastPlayerStateTransferEvent = "applied host save identity saveKey=" + saveKey;
         LogCoop(m_lastPlayerStateTransferEvent);
         return;
@@ -76401,6 +77005,37 @@ void ModMain::HandlePlayerStateTransfer(const CoopProtocol::PlayerStateTransferP
             scopedDest = CoopFilesystem::FromUtf8(scopedPath);
         }
 
+        RecoveryStateMetadata incomingRecovery;
+        const bool incomingIsRecovery =
+            ReadRecoveryStateMetadata(receivePath, incomingRecovery);
+        if (incomingIsRecovery &&
+            (incomingRecovery.accountToken != accountToken ||
+                incomingRecovery.saveKey != storedSaveKey ||
+                storedSaveKey.empty()))
+        {
+            failUpload(
+                "rejected recovery journal identity account=" +
+                Hex64(accountToken));
+            return;
+        }
+
+        bool recoveryAlreadyStored = false;
+        if (incomingIsRecovery && !scopedDest.empty())
+        {
+            RecoveryStateMetadata existingRecovery;
+            if (ReadRecoveryStateMetadata(scopedDest, existingRecovery) &&
+                existingRecovery.accountToken == accountToken &&
+                existingRecovery.saveKey == storedSaveKey &&
+                existingRecovery.revision >= incomingRecovery.revision)
+            {
+                recoveryAlreadyStored = true;
+                LogCoop(
+                    "idempotent recovery journal upload already stored account=" +
+                    Hex64(accountToken) +
+                    " revision=" + std::to_string(incomingRecovery.revision));
+            }
+        }
+
         const auto commitStateFile = [&](const std::filesystem::path& destination, const char* label)
         {
             std::error_code commitError;
@@ -76457,7 +77092,7 @@ void ModMain::HandlePlayerStateTransfer(const CoopProtocol::PlayerStateTransferP
             return true;
         };
 
-        if (!scopedDest.empty())
+        if (!recoveryAlreadyStored && !scopedDest.empty())
         {
             // The exact save-scoped state is preferred on reconnect. Commit it
             // first so a later failure updating the latest alias can never leave
@@ -76469,7 +77104,7 @@ void ModMain::HandlePlayerStateTransfer(const CoopProtocol::PlayerStateTransferP
             }
         }
 
-        if (!commitStateFile(latestDest, "latest"))
+        if (!recoveryAlreadyStored && !commitStateFile(latestDest, "latest"))
         {
             failUpload("cannot store client player state: latest commit failed");
             return;
@@ -76541,6 +77176,39 @@ void ModMain::HandlePlayerStateTransfer(const CoopProtocol::PlayerStateTransferP
             return;
         }
 
+        if (m_networkMode == CoopNetworkMode::Client &&
+            hostAuthoritative &&
+            m_clientDisconnectFlushPending)
+        {
+            // A final disconnect upload owns the shared transfer state until
+            // its StoredAck or deadline. Replacing it with a late host push
+            // would strand the immutable inventory snapshot mid-transfer.
+            m_lastPlayerStateTransferEvent =
+                "ignored host player state during disconnect inventory flush";
+            LogCoop(m_lastPlayerStateTransferEvent);
+            return;
+        }
+
+        // Upload and receive share the legacy transfer bookkeeping. If a
+        // host-authoritative Start overtakes a recovery upload, retain the
+        // recovery journal request and retry that upload after this incoming
+        // transfer completes instead of losing the request or dropping Start.
+        if (m_networkMode == CoopNetworkMode::Client &&
+            hostAuthoritative &&
+            m_clientRecoveryJournalPending &&
+            m_clientRecoveryJournalAwaitingStoredAck &&
+            m_playerStateTransferSending)
+        {
+            m_clientRecoveryJournalAwaitingStoredAck = false;
+            m_clientRecoveryJournalChecksum = 0;
+        }
+
+        if (m_networkMode == CoopNetworkMode::Client && hostAuthoritative && !saveKey.empty())
+        {
+            SetCurrentHostSaveStateKey(saveKey, true);
+            RecoverLocalPlayerRecoveryJournal("host player state identity");
+        }
+
         m_playerStateTransferId = packet.transferId;
         m_playerStateTransferTotalBytes = packet.totalBytes;
         m_playerStateTransferChunkCount = packet.chunkCount;
@@ -76552,9 +77220,9 @@ void ModMain::HandlePlayerStateTransfer(const CoopProtocol::PlayerStateTransferP
         m_playerStateTransferUsername = username.empty() ? std::string("Player") : username;
         m_playerStateTransferAccountToken = packet.accountToken;
         m_playerStateTransferSaveKey = saveKey;
-        if (m_networkMode == CoopNetworkMode::Client && hostAuthoritative && !saveKey.empty())
-            SetCurrentHostSaveStateKey(saveKey, true);
         m_playerStateTransferReceivePath = BuildCoopTempPlayerStatePath(packet.transferId, m_playerStateTransferUsername);
+        if (m_networkMode == CoopNetworkMode::Client && hostAuthoritative)
+            m_pendingHostAuthoritativePlayerStateReceivePath = m_playerStateTransferReceivePath;
         m_playerStateTransferSending = false;
         m_playerStateTransferReceiving = true;
         m_playerStateTransferStarted = true;
@@ -76703,6 +77371,25 @@ void ModMain::HandlePlayerStateTransfer(const CoopProtocol::PlayerStateTransferP
 
         if (m_networkMode == CoopNetworkMode::Client && hostAuthoritative)
         {
+            if (m_clientRecoveryJournalPending &&
+                !m_clientRecoveryJournalSourcePath.empty() &&
+                m_clientRecoveryJournalSaveKey == m_currentHostSaveStateKey)
+            {
+                PlayerSidecarState recoveryState;
+                if (!LoadPlayerSidecarFromPath(m_clientRecoveryJournalSourcePath, recoveryState))
+                {
+                    m_lastPlayerStateTransferEvent =
+                        "failed to stage recovery journal after host player state transfer";
+                    LogCoop(m_lastPlayerStateTransferEvent);
+                    return;
+                }
+                // Keep the newer local snapshot in memory while its durable
+                // journal is uploaded and deleted after StoredAck. The host's
+                // older transfer remains useful for join sequencing only.
+                m_pendingNativePlayerStateOverride = std::move(recoveryState);
+                m_pendingNativePlayerStateOverrideValid = true;
+            }
+
             if (m_pendingHostWorldLoadAfterPlayerState)
             {
                 if (!PrepareReceivedPlayerStateForHostLoad("preload host player state"))

--- a/CoopPrototype/Src/ModMain.h
+++ b/CoopPrototype/Src/ModMain.h
@@ -1686,6 +1686,7 @@ public:
     void OnNativeSharedItemDropped(CArkItem* item, int droppedCount, const char* reason);
     bool ShouldDeferNativeSharedItemPickup(CArkItem* item, EntityId pickerId, const char* reason);
     void OnNativeSharedItemPicked(EntityId itemEntityId, EntityId pickerId, bool success, const char* reason);
+    void CaptureLocalPlayerPickupRecovery(EntityId pickerId, const char* reason);
     void OnSharedDropEntityRemoved(EntityId entityId);
     bool ShouldDeferSharedStorageOpen(CArkExternalInventoryUI* ui, ArkInventory* inventory, const char* reason);
     void OnSharedStorageTransfer(CArkItem* item, IArkInventory* source, IArkInventory* target, const char* reason);

--- a/CoopPrototype/Src/ModMain.h
+++ b/CoopPrototype/Src/ModMain.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <array>
 #include <deque>
@@ -702,7 +703,11 @@ public:
     void OnArkItemLifecycleHook(CArkItem* item, const char* functionName);
     void OnArkInventoryMutationHook(const ArkInventory* inventory, const char* functionName, unsigned itemId, unsigned relatedItemId, int x, int y, bool boolResult, unsigned unsignedResult);
     void OnArkItemOwnerMutationHook(CArkItem* item, const char* functionName, unsigned pickerId, const IArkInventory* inventory, bool result);
-    void OnArkItemResetCountHook(CArkItem* item, int count);
+    void MarkLocalInventoryDirty(const char* reason);
+    bool IsLocalInventoryDirtyForSaveKey(const std::string& saveKey) const;
+    void ReconcileLocalInventoryDirtyForSaveKey(const std::string& saveKey);
+    bool HandleNativeWindowMessage(std::uintptr_t windowHandle, unsigned message, uint64_t wParam, std::int64_t lParam);
+    void OnArkItemResetCountHook(CArkItem* item, int count, unsigned ownerIdBefore);
     bool ShouldSuppressPlayerSidecarInventoryFeedback() const;
     void BeginPlayerSidecarInventoryFeedbackSuppression(const char* reason);
     void EndPlayerSidecarInventoryFeedbackSuppression(const char* reason);
@@ -2118,8 +2123,10 @@ private:
     bool BeginHostPlayerStateTransfer(const char* reason, const std::string& requestedSaveKey = {});
     bool BeginClientPlayerStateUpload(const char* reason, const std::string& saveKey = {});
     void QueueClientPlayerStateUpload(const char* reason, const std::string& saveKey = {});
-    bool BeginClientIntentionalDisconnect(const char* reason);
+    bool BeginClientIntentionalDisconnect(const char* reason, bool captureImmediately = true);
     void TickClientIntentionalDisconnect(float frameTime);
+    bool CaptureClientDisconnectSnapshot();
+    void ResumeDeferredNativeWindowClose();
     bool RequestRemotePlayerStateUpload(const char* reason);
     bool BroadcastHostSaveIdentity(const char* reason);
     bool StartClientNativePlayerSnapshotForUpload(const char* reason, const std::string& saveKey);
@@ -2782,9 +2789,20 @@ private:
     bool DebugTraceNativeEntityLifecycle(const std::vector<std::string>& args, std::string& detail);
     bool DebugTraceNativeNpcSpawn(const std::vector<std::string>& args, std::string& detail);
     std::string GetPlayerSidecarPath() const;
+    std::string GetPlayerSidecarRecoveryJournalPath() const;
     bool SaveLocalPlayerSidecar(const char* reason);
     bool LoadLocalPlayerSidecar(PlayerSidecarState& state);
     bool LoadPlayerSidecarFromPath(const std::string& path, PlayerSidecarState& state);
+    bool HasValidPlayerSidecarRecoveryJournal() const;
+    uint64_t GetPlayerSidecarRecoveryJournalRevision() const;
+    bool WriteLocalPlayerRecoveryJournal(const char* reason);
+    bool ClearLocalPlayerRecoveryJournal(
+        const std::string& sourcePath,
+        uint64_t accountToken,
+        const std::string& saveKey,
+        uint64_t revision,
+        const char* reason);
+    bool RecoverLocalPlayerRecoveryJournal(const char* reason);
     bool ApplyLocalPlayerSidecar(const PlayerSidecarState& state, const char* reason);
     bool RestorePlayerSidecarEquipment(const PlayerSidecarState& state, const char* reason);
     void QueuePlayerSidecarInventoryRestore(const std::vector<PlayerInventoryItemState>& items, bool clearInventory, const char* reason);
@@ -4540,6 +4558,10 @@ private:
     bool m_pendingHostPlayerStateSend = false;
     bool m_pendingClientPlayerStateUpload = false;
     bool m_pendingReceivedPlayerStateApply = false;
+    // The client can upload its recovery journal before applying a completed
+    // host transfer. Keep the received host file addressable while the shared
+    // transfer fields are temporarily used for that upload.
+    std::string m_pendingHostAuthoritativePlayerStateReceivePath;
     bool m_pendingNativePlayerStateOverrideValid = false;
     PlayerSidecarState m_pendingNativePlayerStateOverride;
     bool m_clientAwaitingHostPlayerState = false;
@@ -4559,6 +4581,19 @@ private:
     uint32_t m_hostPlayerStateSentWorldEpoch = 0;
     float m_receivedPlayerStateApplyDelaySeconds = 0.0f;
     bool m_pendingPlayerSidecarSave = false;
+    bool m_localInventoryDirty = false;
+    std::string m_localInventoryDirtySaveKey;
+    uint64_t m_localInventoryDirtyRevision = 0;
+    uint64_t m_localInventoryJournalRevision = 0;
+    float m_localInventoryJournalAccumulator = 0.0f;
+    bool m_clientRecoveryJournalPending = false;
+    bool m_clientRecoveryJournalAwaitingStoredAck = false;
+    bool m_clientRecoveryJournalStoredAckReceived = false;
+    uint32_t m_clientRecoveryJournalTransferId = 0;
+    uint32_t m_clientRecoveryJournalChecksum = 0;
+    uint64_t m_clientRecoveryJournalRevision = 0;
+    std::string m_clientRecoveryJournalSourcePath;
+    std::string m_clientRecoveryJournalSaveKey;
     bool m_pendingPlayerSidecarApply = false;
     bool m_pendingPlayerSidecarInventoryRestore = false;
     bool m_pendingPlayerSidecarInventoryRestoreNeedsClear = false;
@@ -4642,11 +4677,22 @@ private:
     bool m_clientDisconnectFlushPending = false;
     bool m_clientDisconnectFlushAwaitingStoredAck = false;
     bool m_clientDisconnectFlushStoredAckReceived = false;
+    bool m_clientDisconnectFlushCaptureAttempted = false;
     uint32_t m_clientDisconnectFlushTransferId = 0;
     uint32_t m_clientDisconnectFlushChecksum = 0;
     float m_clientDisconnectFlushRemainingSeconds = 0.0f;
+    float m_clientDisconnectFlushCaptureRetrySeconds = 0.0f;
+    std::chrono::steady_clock::time_point m_clientDisconnectFlushDeadline;
     std::string m_clientDisconnectFlushReason;
     std::string m_clientDisconnectFlushSaveKey;
+    std::string m_clientDisconnectFlushJournalSourcePath;
+    uint64_t m_clientDisconnectFlushJournalRevision = 0;
+    bool m_nativeWindowCloseDeferred = false;
+    bool m_nativeWindowCloseReentry = false;
+    std::uintptr_t m_nativeWindowCloseHandle = 0;
+    unsigned m_nativeWindowCloseMessage = 0;
+    uint64_t m_nativeWindowCloseWParam = 0;
+    std::int64_t m_nativeWindowCloseLParam = 0;
     uint64_t m_multiplayerKickRequestedToken = 0;
     uint64_t m_multiplayerInputSuppressUntilMs = 0;
     float m_multiplayerUiMouseX = -1.0f;


### PR DESCRIPTION
## Summary
- add a hardened, save-key-scoped local inventory journal that is refreshed after inventory mutations
- synchronously journal successful local pickups, closing the immediate hard-kill window before the normal mutation debounce
- defer native Windows close requests long enough to upload the latest immutable player state and receive the host's `StoredAck`
- retain the journal through crashes, forced exits, transport loss, and bounded close timeouts, then recover it on the next matching reconnect
- prevent stale journals, in-flight acknowledgements, and completed save transfers from affecting another account or host save

## Verification
- MSVC xwin build passed
- ABI smoke test passed
- live Linux host / native Windows client graceful-close test preserved the latest inventory and cleared the journal only after `StoredAck`
- host-unavailable test exited after the bounded timeout, retained the recovery journal, and restored the exact inventory after reconnect
- same-account reconnect against the same running host completed without a stale save-transfer stall
- stackable non-weapon deletion persisted across graceful close and reconnect (`Neuromod count: 5 -> 0 -> 0`)
- normal-item SharedDrop hard-kill test: Windows picked up exactly one Banana while host upload counters stayed at zero, was force-killed, then recovered exactly one Banana after reconnect; the journal cleared only after `StoredAck`
- duplicate-source hard-kill test: host exact/latest client state and the surviving client recovery journal both contained exactly one Banana; reconnect converged to exactly one Banana on both host and client, then cleared revision 3 only after `StoredAck`
- independent final review confirmed save-key isolation and found no remaining high-confidence blocker
- `git diff --check`

Forced process termination cannot run the close hook; the synchronously refreshed local journal is the fallback for successful pickups, while the normal mutation journal covers other inventory changes.