### PR TITLE
Add session text chat

### DIFF
--- a/CoopPrototype/Src/CMakeLists.txt
+++ b/CoopPrototype/Src/CMakeLists.txt
@@ -9,6 +9,8 @@ set(SOURCE_FILES
 	CoopAreaStateOverlay.cpp
 	CoopAreaStateOverlay.h
 	CoopAnimationTest.cpp
+	CoopChat.cpp
+	CoopChat.h
 	CoopBreakableSync.cpp
 	CoopAssetDump.cpp
 	CoopCoverageDiscovery.cpp
@@ -101,6 +103,7 @@ set(SOURCE_FILES
 	CoopProtocol.h
 	CoopVTableHook.h
 	ModMain.cpp
+	ModMainChat.cpp
 	ModMain.h
 	pch.h
 )

--- a/CoopPrototype/Src/CoopChat.cpp
+++ b/CoopPrototype/Src/CoopChat.cpp
@@ -1,0 +1,406 @@
+#include "CoopChat.h"
+#include "CoopSerialSequence.h"
+
+#include <Windows.h>
+
+#ifdef min
+#undef min
+#endif
+#ifdef max
+#undef max
+#endif
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <sstream>
+#include <utility>
+
+namespace
+{
+constexpr float kChatLineLifetimeSeconds = 8.0f;
+constexpr size_t kMaxChatLines = 32;
+
+uint32_t CombineSurrogate(uint16_t high, uint16_t low)
+{
+    return 0x10000u + ((static_cast<uint32_t>(high) - 0xd800u) << 10) +
+        (static_cast<uint32_t>(low) - 0xdc00u);
+}
+}
+
+void CoopChat::SetDatagramSender(DatagramSender sender)
+{
+    m_sendDatagram = std::move(sender);
+}
+
+void CoopChat::SetIdentity(uint64_t accountToken, const std::string& username)
+{
+    m_accountToken = accountToken;
+    if (!username.empty())
+        m_username = username;
+}
+
+void CoopChat::SetConnected(bool connected)
+{
+    if (m_connected == connected)
+        return;
+
+    m_connected = connected;
+    if (!connected)
+    {
+        m_chatOpen = false;
+        m_input.clear();
+        m_pendingHighSurrogate = 0;
+        m_ignoreNextChar = false;
+    }
+}
+
+void CoopChat::Tick(float frameTime, float nowSeconds)
+{
+    if (std::isfinite(nowSeconds) && nowSeconds >= 0.0f)
+        m_lastTickSeconds = nowSeconds;
+    else if (std::isfinite(frameTime) && frameTime > 0.0f)
+        m_lastTickSeconds += std::min(frameTime, 0.25f);
+}
+
+void CoopChat::Reset()
+{
+    m_connected = false;
+    m_chatOpen = false;
+    m_ignoreNextChar = false;
+    m_pendingHighSurrogate = 0;
+    m_input.clear();
+    m_chatLines.clear();
+    m_lastTextSequences.clear();
+    m_textSequence = 0;
+    m_textSent = 0;
+    m_textReceived = 0;
+    m_lastTickSeconds = 0.0f;
+}
+
+bool CoopChat::HandleNativeWindowMessage(unsigned message, uint64_t wParam, int64_t lParam)
+{
+    if (!m_connected)
+        return false;
+
+    const bool keyDown = message == WM_KEYDOWN || message == WM_SYSKEYDOWN;
+    const bool keyUp = message == WM_KEYUP || message == WM_SYSKEYUP;
+    const uint32_t key = static_cast<uint32_t>(wParam & 0xffffu);
+    const bool chatOpenKey = key == 'Y' || key == VK_OEM_5 || key == VK_OEM_PLUS;
+
+    // The opening key is also delivered as WM_CHAR by the native window.
+    // Consume that character so it cannot leak into the first chat line.
+    if (message == WM_CHAR && m_ignoreNextChar)
+    {
+        m_ignoreNextChar = false;
+        return true;
+    }
+
+    if (!m_chatOpen && keyDown && chatOpenKey &&
+        (static_cast<uint64_t>(lParam) & (1ull << 30)) == 0)
+    {
+        m_chatOpen = true;
+        m_ignoreNextChar = true;
+        m_pendingHighSurrogate = 0;
+        return true;
+    }
+
+    if (!m_chatOpen)
+        return false;
+
+    // Chat owns keyboard input only. Window lifecycle, focus, mouse and other
+    // native messages must still reach the game's existing handlers.
+    if (!keyDown && !keyUp && message != WM_CHAR)
+        return false;
+
+    if (keyDown && chatOpenKey)
+        return true;
+
+    if (keyDown)
+    {
+        if (key == VK_ESCAPE)
+        {
+            m_chatOpen = false;
+            m_input.clear();
+            m_pendingHighSurrogate = 0;
+            return true;
+        }
+        if (key == VK_RETURN)
+        {
+            m_ignoreNextChar = true;
+            SubmitInput();
+            return true;
+        }
+        if (key == VK_BACK || key == VK_LEFT || key == VK_RIGHT ||
+            key == VK_UP || key == VK_DOWN || key == VK_HOME || key == VK_END || key == VK_DELETE)
+            return true;
+    }
+
+    if (message == WM_CHAR)
+    {
+        if (key == VK_RETURN || key == VK_ESCAPE)
+            return true;
+        if (key == VK_BACK)
+        {
+            if (!m_input.empty())
+            {
+                size_t offset = m_input.size() - 1;
+                while (offset > 0 && (static_cast<unsigned char>(m_input[offset]) & 0xc0u) == 0x80u)
+                    --offset;
+                m_input.erase(offset);
+            }
+            return true;
+        }
+        if (key >= 0x20 && key != 0x7f)
+            AppendInputUtf16(static_cast<uint16_t>(key));
+        return true;
+    }
+
+    return keyDown || keyUp;
+}
+
+bool CoopChat::SendText(const std::string& text)
+{
+    if (!m_connected || m_accountToken == 0 || !m_sendDatagram)
+        return false;
+
+    const std::string limited = LimitUtf8(text);
+    if (limited.empty())
+        return false;
+
+    CoopProtocol::TextChatPacket packet = {};
+    packet.sequence = CoopSerialSequence::Advance(m_textSequence);
+    packet.sourceAccountToken = m_accountToken;
+    packet.textLength = static_cast<uint16_t>(limited.size());
+    std::memcpy(packet.text, limited.data(), limited.size());
+    if (!m_sendDatagram(&packet, sizeof(packet), "chat send failed"))
+        return false;
+
+    ++m_textSent;
+    AddChatLine(m_username, limited, m_lastTickSeconds);
+    m_chatOpen = false;
+    m_input.clear();
+    m_pendingHighSurrogate = 0;
+    return true;
+}
+
+bool CoopChat::HandleTextPacket(
+    const CoopProtocol::TextChatPacket& packet,
+    const std::string& username,
+    float nowSeconds)
+{
+    if (!CanAcceptTextPacket(packet))
+        return false;
+
+    m_lastTextSequences[packet.sourceAccountToken] = packet.sequence;
+    AddChatLine(
+        username.empty() ? "Player" : username,
+        std::string(packet.text, packet.text + packet.textLength),
+        nowSeconds);
+    ++m_textReceived;
+    return true;
+}
+
+bool CoopChat::CanAcceptTextPacket(const CoopProtocol::TextChatPacket& packet) const
+{
+    if (packet.sourceAccountToken == 0 || packet.sequence == 0 || packet.textLength == 0 ||
+        packet.textLength > CoopProtocol::kTextChatMaxUtf8Bytes)
+        return false;
+
+    const auto sequenceIt = m_lastTextSequences.find(packet.sourceAccountToken);
+    if (sequenceIt != m_lastTextSequences.end() &&
+        CoopSerialSequence::IsStaleOrDuplicate(packet.sequence, sequenceIt->second))
+        return false;
+
+    size_t characters = 0;
+    return IsValidUtf8(packet.text, packet.textLength, &characters) &&
+        characters != 0 && characters <= CoopProtocol::kTextChatMaxUtf8Chars;
+}
+
+void CoopChat::RemoveSender(uint64_t accountToken)
+{
+    m_lastTextSequences.erase(accountToken);
+}
+
+CoopChat::HudState CoopChat::BuildHudState(float nowSeconds) const
+{
+    const float currentSeconds = std::isfinite(nowSeconds) ? nowSeconds : m_lastTickSeconds;
+    HudState state;
+    size_t lineCount = 0;
+    for (auto it = m_chatLines.rbegin(); it != m_chatLines.rend(); ++it)
+    {
+        const float age = std::max(0.0f, currentSeconds - it->receivedAt);
+        if (age >= kChatLineLifetimeSeconds)
+            continue;
+        const std::string line = it->username + ": " + it->text;
+        state.text = state.text.empty() ? line : line + "\n" + state.text;
+        if (++lineCount >= 10)
+            break;
+    }
+
+    if (m_chatOpen)
+    {
+        if (!state.text.empty())
+            state.text += "\n";
+        state.text += "CHAT > " + m_input + "_";
+    }
+    return state;
+}
+
+std::string CoopChat::BuildTelemetry() const
+{
+    std::ostringstream out;
+    out << "chat=" << m_textSent << "/" << m_textReceived
+        << ",typing=" << (m_chatOpen ? 1 : 0);
+    return out.str();
+}
+
+void CoopChat::AppendInputUtf16(uint16_t value)
+{
+    if (value >= 0xd800u && value <= 0xdbffu)
+    {
+        if (m_pendingHighSurrogate != 0)
+            m_input += WideCharToUtf8(m_pendingHighSurrogate);
+        m_pendingHighSurrogate = value;
+        return;
+    }
+    if (value >= 0xdc00u && value <= 0xdfffu)
+    {
+        if (m_pendingHighSurrogate != 0)
+        {
+            const std::string encoded =
+                WideCharToUtf8(CombineSurrogate(m_pendingHighSurrogate, value));
+            const std::string candidate = m_input + encoded;
+            if (candidate.size() <= CoopProtocol::kTextChatMaxUtf8Bytes &&
+                LimitUtf8(candidate).size() == candidate.size())
+                m_input = candidate;
+            m_pendingHighSurrogate = 0;
+        }
+        return;
+    }
+    if (m_pendingHighSurrogate != 0)
+    {
+        m_input += WideCharToUtf8(m_pendingHighSurrogate);
+        m_pendingHighSurrogate = 0;
+    }
+    const std::string encoded = WideCharToUtf8(value);
+    const std::string candidate = m_input + encoded;
+    if (candidate.size() > CoopProtocol::kTextChatMaxUtf8Bytes ||
+        LimitUtf8(candidate).size() != candidate.size())
+        return;
+    m_input = candidate;
+}
+
+void CoopChat::SubmitInput()
+{
+    if (!m_input.empty())
+        SendText(m_input);
+    else
+        m_chatOpen = false;
+}
+
+void CoopChat::AddChatLine(const std::string& username, const std::string& text, float nowSeconds)
+{
+    if (text.empty())
+        return;
+    m_chatLines.push_back({username.empty() ? "Player" : username, text, nowSeconds});
+    while (m_chatLines.size() > kMaxChatLines)
+        m_chatLines.pop_front();
+}
+
+std::string CoopChat::LimitUtf8(const std::string& text)
+{
+    size_t chars = 0;
+    size_t offset = 0;
+    while (offset < text.size() && chars < CoopProtocol::kTextChatMaxUtf8Chars)
+    {
+        const unsigned char first = static_cast<unsigned char>(text[offset]);
+        size_t width = 1;
+        if (first >= 0xc2u && first <= 0xdfu)
+            width = 2;
+        else if (first >= 0xe0u && first <= 0xefu)
+            width = 3;
+        else if (first >= 0xf0u && first <= 0xf4u)
+            width = 4;
+        if (offset + width > text.size() || !IsValidUtf8(text.data() + offset, width, nullptr))
+            break;
+        offset += width;
+        ++chars;
+    }
+    return text.substr(0, std::min(offset, CoopProtocol::kTextChatMaxUtf8Bytes));
+}
+
+bool CoopChat::IsValidUtf8(const char* text, size_t length, size_t* outCharacters)
+{
+    if (outCharacters)
+        *outCharacters = 0;
+    if (!text)
+        return false;
+
+    size_t offset = 0;
+    size_t characters = 0;
+    while (offset < length)
+    {
+        const unsigned char first = static_cast<unsigned char>(text[offset]);
+        size_t width = 0;
+        if (first <= 0x7fu)
+            width = 1;
+        else if (first >= 0xc2u && first <= 0xdfu)
+            width = 2;
+        else if (first >= 0xe0u && first <= 0xefu)
+            width = 3;
+        else if (first >= 0xf0u && first <= 0xf4u)
+            width = 4;
+        else
+            return false;
+        if (offset + width > length)
+            return false;
+        uint32_t codepoint = first & (width == 1 ? 0x7fu : width == 2 ? 0x1fu : width == 3 ? 0x0fu : 0x07u);
+        for (size_t i = 1; i < width; ++i)
+        {
+            const unsigned char continuation = static_cast<unsigned char>(text[offset + i]);
+            if ((continuation & 0xc0u) != 0x80u)
+                return false;
+            codepoint = (codepoint << 6) | (continuation & 0x3fu);
+        }
+        if ((width == 2 && codepoint < 0x80u) ||
+            (width == 3 && codepoint < 0x800u) ||
+            (width == 4 && codepoint < 0x10000u) ||
+            codepoint > 0x10ffffu || (codepoint >= 0xd800u && codepoint <= 0xdfffu) ||
+            codepoint <= 0x1fu || (codepoint >= 0x7fu && codepoint <= 0x9fu))
+            return false;
+        offset += width;
+        ++characters;
+    }
+    if (outCharacters)
+        *outCharacters = characters;
+    return true;
+}
+
+std::string CoopChat::WideCharToUtf8(uint32_t codepoint)
+{
+    if (codepoint > 0x10ffffu || (codepoint >= 0xd800u && codepoint <= 0xdfffu))
+        return {};
+    std::string result;
+    if (codepoint <= 0x7fu)
+        result.push_back(static_cast<char>(codepoint));
+    else if (codepoint <= 0x7ffu)
+    {
+        result.push_back(static_cast<char>(0xc0u | (codepoint >> 6)));
+        result.push_back(static_cast<char>(0x80u | (codepoint & 0x3fu)));
+    }
+    else if (codepoint <= 0xffffu)
+    {
+        result.push_back(static_cast<char>(0xe0u | (codepoint >> 12)));
+        result.push_back(static_cast<char>(0x80u | ((codepoint >> 6) & 0x3fu)));
+        result.push_back(static_cast<char>(0x80u | (codepoint & 0x3fu)));
+    }
+    else
+    {
+        result.push_back(static_cast<char>(0xf0u | (codepoint >> 18)));
+        result.push_back(static_cast<char>(0x80u | ((codepoint >> 12) & 0x3fu)));
+        result.push_back(static_cast<char>(0x80u | ((codepoint >> 6) & 0x3fu)));
+        result.push_back(static_cast<char>(0x80u | (codepoint & 0x3fu)));
+    }
+    return result;
+}

--- a/CoopPrototype/Src/CoopChat.h
+++ b/CoopPrototype/Src/CoopChat.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "CoopProtocol.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <string>
+#include <unordered_map>
+
+class CoopChat final
+{
+public:
+    using DatagramSender = std::function<bool(const void* data, size_t size, const char* failurePrefix)>;
+
+    CoopChat() = default;
+    ~CoopChat() = default;
+
+    CoopChat(const CoopChat&) = delete;
+    CoopChat& operator=(const CoopChat&) = delete;
+
+    struct HudState
+    {
+        std::string text;
+    };
+
+    void SetDatagramSender(DatagramSender sender);
+    void SetIdentity(uint64_t accountToken, const std::string& username);
+    void SetConnected(bool connected);
+    void Tick(float frameTime, float nowSeconds);
+    HudState BuildHudState(float nowSeconds) const;
+    bool HandleNativeWindowMessage(unsigned message, uint64_t wParam, int64_t lParam);
+    bool SendText(const std::string& text);
+    bool CanAcceptTextPacket(const CoopProtocol::TextChatPacket& packet) const;
+    bool HandleTextPacket(const CoopProtocol::TextChatPacket& packet, const std::string& username, float nowSeconds);
+    void RemoveSender(uint64_t accountToken);
+    bool IsInputOpen() const { return m_chatOpen; }
+    std::string BuildTelemetry() const;
+    void Reset();
+
+private:
+    struct ChatLine
+    {
+        std::string username;
+        std::string text;
+        float receivedAt = 0.0f;
+    };
+
+    void AppendInputUtf16(uint16_t value);
+    void SubmitInput();
+    void AddChatLine(const std::string& username, const std::string& text, float nowSeconds);
+    static std::string LimitUtf8(const std::string& text);
+    static bool IsValidUtf8(const char* text, size_t length, size_t* outCharacters);
+    static std::string WideCharToUtf8(uint32_t codepoint);
+
+    DatagramSender m_sendDatagram;
+    uint64_t m_accountToken = 0;
+    std::string m_username = "Player";
+    bool m_connected = false;
+    bool m_chatOpen = false;
+    bool m_ignoreNextChar = false;
+    uint32_t m_textSequence = 0;
+    uint16_t m_pendingHighSurrogate = 0;
+    std::string m_input;
+    std::deque<ChatLine> m_chatLines;
+    std::unordered_map<uint64_t, uint32_t> m_lastTextSequences;
+    float m_lastTickSeconds = 0.0f;
+    uint64_t m_textSent = 0;
+    uint64_t m_textReceived = 0;
+};

--- a/CoopPrototype/Src/CoopNetworkTelemetry.cpp
+++ b/CoopPrototype/Src/CoopNetworkTelemetry.cpp
@@ -17,7 +17,7 @@ struct PacketDescriptor
     const char* delivery;
 };
 
-constexpr std::array<PacketDescriptor, 30> kPacketDescriptors = {{
+constexpr std::array<PacketDescriptor, 31> kPacketDescriptors = {{
     {CoopProtocol::PacketType::PlayerPose, "PlayerPose", sizeof(CoopProtocol::PlayerPosePacket), "direct-variable"},
     {CoopProtocol::PacketType::SessionHello, "SessionHello", sizeof(CoopProtocol::SessionHelloPacket), "direct"},
     {CoopProtocol::PacketType::RemotePlayerDamage, "RemotePlayerDamage", sizeof(CoopProtocol::RemotePlayerDamagePacket), "reliable"},
@@ -48,6 +48,7 @@ constexpr std::array<PacketDescriptor, 30> kPacketDescriptors = {{
     {CoopProtocol::PacketType::DialogueLease, "DialogueLease", sizeof(CoopProtocol::DialogueLeasePacket), "reliable"},
     {CoopProtocol::PacketType::TimeDilation, "TimeDilation", sizeof(CoopProtocol::TimeDilationPacket), "reliable"},
     {CoopProtocol::PacketType::CorpsePhantomRequest, "CorpsePhantomRequest", sizeof(CoopProtocol::CorpsePhantomRequestPacket), "reliable"},
+    {CoopProtocol::PacketType::TextChat, "TextChat", sizeof(CoopProtocol::TextChatPacket), "direct"},
 }};
 
 void Add(CoopNetworkTelemetry::Totals& target, uint64_t packets, uint64_t bytes)

--- a/CoopPrototype/Src/CoopNetworkTelemetry.h
+++ b/CoopPrototype/Src/CoopNetworkTelemetry.h
@@ -8,7 +8,7 @@
 class CoopNetworkTelemetry final
 {
 public:
-    static constexpr size_t kPacketTypeSlots = 32;
+    static constexpr size_t kPacketTypeSlots = 64;
 
     enum class ProducerSuppressionReason : uint8_t
     {

--- a/CoopPrototype/Src/CoopPlayerState.cpp
+++ b/CoopPrototype/Src/CoopPlayerState.cpp
@@ -1596,6 +1596,14 @@ bool ModMain::ShouldSuppressArkPlayerAction(const CCryName& action, int activati
 {
     (void)value;
 
+    if (IsChatInputOpen())
+    {
+        const std::string actionName = ToLowerAscii(action.c_str());
+        ++m_suppressedDownedActions;
+        m_lastSuppressedDownedAction = actionName.empty() ? std::string("chat_input") : "chat_" + actionName;
+        return true;
+    }
+
     if (m_joinOverlayActive && ShouldBlockJoinInput())
     {
         const std::string actionName = ToLowerAscii(action.c_str());

--- a/CoopPrototype/Src/CoopProtocol.h
+++ b/CoopPrototype/Src/CoopProtocol.h
@@ -7,7 +7,7 @@
 namespace CoopProtocol
 {
 constexpr uint32_t kPacketMagic = 0x504F4F43; // "COOP" on little endian
-constexpr uint16_t kProtocolVersion = 242;
+constexpr uint16_t kProtocolVersion = 243;
 constexpr uint32_t kModBuild = 20260725;
 constexpr size_t kUsernameSize = 32;
 constexpr size_t kPasswordSize = 32;
@@ -17,6 +17,8 @@ constexpr size_t kSavePathSize = 96;
 constexpr size_t kSaveKeySize = 64;
 constexpr size_t kWeaponClassNameSize = 64;
 constexpr size_t kMaxPacketSize = 1200;
+constexpr size_t kTextChatMaxUtf8Bytes = 768;
+constexpr size_t kTextChatMaxUtf8Chars = 255;
 constexpr size_t kReliablePayloadSize = 1164;
 constexpr size_t kSaveTransferDataSize = 1024;
 constexpr size_t kPlayerStateTransferDataSize = 960;
@@ -417,6 +419,7 @@ enum class PacketType : uint16_t
     SessionReject = 0x22,
     EnemyMannequinAction = 0x23,
     EnemyDeathPresentation = 0x24,
+    TextChat = 0x25,
 };
 
 enum class EnemyMannequinActionCommand : uint16_t
@@ -1551,6 +1554,18 @@ struct SessionRejectPacket
     uint16_t reserved = 0;
     char message[96] = {};
 };
+
+struct TextChatPacket
+{
+    uint32_t magic = kPacketMagic;
+    uint16_t version = kProtocolVersion;
+    uint16_t type = static_cast<uint16_t>(PacketType::TextChat);
+    uint32_t sequence = 0;
+    uint64_t sourceAccountToken = 0;
+    uint16_t textLength = 0;
+    uint16_t flags = 0;
+    char text[kTextChatMaxUtf8Bytes] = {};
+};
 constexpr size_t kReliableEnvelopeHeaderSize = offsetof(ReliableEnvelopePacket, payload);
 #pragma pack(pop)
 
@@ -1559,6 +1574,7 @@ static_assert(kPlayerPoseBaseWireSize == sizeof(PlayerPosePacket) - kMimicModelP
 static_assert(kPlayerPoseBaseWireSize >= sizeof(PacketHeader));
 static_assert(sizeof(PlayerPosePacket) <= kMaxPacketSize);
 static_assert(sizeof(SessionHelloPacket) <= kMaxPacketSize);
+static_assert(sizeof(TextChatPacket) <= kMaxPacketSize);
 static_assert(sizeof(AreaLeasePacket) <= kReliablePayloadSize);
 static_assert(sizeof(RemotePlayerDamagePacket) <= kMaxPacketSize);
 static_assert(sizeof(TestMimicSpawnPacket) <= kMaxPacketSize);

--- a/CoopPrototype/Src/ModMain.cpp
+++ b/CoopPrototype/Src/ModMain.cpp
@@ -1,5 +1,6 @@
 #include "ModMain.h"
 #include "CoopRuntimeGuards.h"
+#include "CoopChat.h"
 #include "CoopHookStats.h"
 #include "CoopWorkstationSync.h"
 #include "CoopSerialSequence.h"
@@ -7260,6 +7261,7 @@ void ModMain::CoopRenderListener::EndFrame()
 
 ModMain::~ModMain()
 {
+    ShutdownChat();
     CloseServerBrowserSocket();
     UnregisterCoopRenderListener();
     RemoveCrashExceptionHandler();
@@ -31070,6 +31072,9 @@ bool ModMain::HandleNativeWindowMessage(
     uint64_t wParam,
     std::int64_t lParam)
 {
+    if (HandleChatWindowMessage(message, wParam, lParam))
+        return true;
+
     const bool isSystemClose =
         message == WM_SYSCOMMAND && (wParam & 0xFFF0u) == SC_CLOSE;
     const bool isClose = message == WM_CLOSE || isSystemClose;
@@ -31661,6 +31666,7 @@ void ModMain::InitSystem(const ModInitInfo& initInfo, ModDllInfo& dllInfo)
 void ModMain::InitGame(bool isHotReloading)
 {
     BaseClass::InitGame(isHotReloading);
+    InitializeChat();
     InstallCrashExceptionHandler();
     RegisterSystemEventListener();
     if (!EnvFlagEnabled("COOP_DISABLE_ENTITY_SINK"))
@@ -35351,6 +35357,7 @@ void ModMain::MainUpdate(unsigned updateFlags)
     TickPendingRemoteCorpsePhantomResults();
 
     TickNetwork(frameTime);
+    TickChat(frameTime, GetNowSeconds());
     TickRemotePlayerProxySmoothing(frameTime);
     TickRemoteDoorPowerConvergence(frameTime);
     TickArkElevatorTransitScan(frameTime);
@@ -37428,6 +37435,7 @@ std::string ModMain::BuildRuntimeControlStatus() const
         << " reliableSeq=" << m_reliableSendSequence << "/" << m_reliableRecvSequence << "/" << m_reliableAckedSequence
         << " reliableLast=" << StatusToken(m_lastReliableEvent)
         << " netTelemetry=" << m_networkTelemetry.BuildCompactStatus()
+        << " chat=" << StatusToken(BuildChatTelemetry())
         << " runtimeCost=" << StatusToken(BuildRuntimeCostReport())
         << " coverage=" << StatusToken(m_coverageDiscovery.BuildCompactReport())
         << " saveSend=" << (m_saveTransferSending ? 1 : 0)
@@ -42813,6 +42821,19 @@ bool ModMain::HandleRuntimeControlCommand(const std::string& command, const std:
     if (command == "coop_status" || command == "coop")
     {
         action = "status";
+    }
+    else if (command == "coop_chat_send")
+    {
+        std::string text;
+        for (size_t index = 0; index < args.size(); ++index)
+        {
+            if (!text.empty())
+                text += ' ';
+            text += args[index];
+        }
+        ok = SendChatTextCommand(text);
+        action = ok ? "chat_sent" : "chat_send_failed";
+        commandDetail = BuildChatTelemetry();
     }
     else if (command == "coop_network_report")
     {
@@ -52697,6 +52718,8 @@ void ModMain::StartClient()
 
 void ModMain::StopNetwork()
 {
+    ResetChat();
+    m_chatTextRates.clear();
     const bool preserveClientInventoryRecovery =
         m_networkMode == CoopNetworkMode::Client &&
         (m_clientDisconnectFlushPending ||
@@ -68925,6 +68948,8 @@ void ModMain::RemoveRemotePeer(uint64_t accountToken, const char* reason, bool a
     m_reliableEndpointStates.erase(MakeEndpointKey(peer.address, peer.port));
     m_hostPlayerStateUploadReceives.erase(accountToken);
     m_pendingHostPlayerStateUploadRequests.erase(accountToken);
+    RemoveChatSender(accountToken);
+    m_chatTextRates.erase(accountToken);
     m_remotePeers.erase(it);
     for (const EntityId entityId : reclaimedTurretEntities)
     {
@@ -69133,6 +69158,14 @@ void ModMain::TickReceivePackets(const char* failurePrefix)
             HandleReliableEnvelope(packet, fromAddress.sin_addr.s_addr, fromAddress.sin_port);
             continue;
         }
+
+        if (HandleChatDatagram(
+                header,
+                packetBuffer,
+                receivedBytes,
+                fromAddress.sin_addr.s_addr,
+                fromAddress.sin_port))
+            continue;
 
         if (header.type == static_cast<uint16_t>(CoopProtocol::PacketType::GooResult))
         {

--- a/CoopPrototype/Src/ModMain.h
+++ b/CoopPrototype/Src/ModMain.h
@@ -42,6 +42,7 @@
 #include <Prey/GameDll/EntityUtility/EntityEffects.h>
 
 class ArkNpc;
+class CoopChat;
 class ArkLevelTransitionDoor;
 class ArkWorldUIOwner;
 class ArkSaveLoadSystem;
@@ -1809,6 +1810,25 @@ private:
     bool BuildPlayerStateTransferPacket(CoopProtocol::PlayerStateTransferPacket& packet, CoopProtocol::PlayerStateTransferCommand command, uint32_t transferId);
     bool BuildAreaJournalTransferPacket(CoopProtocol::AreaJournalTransferPacket& packet, CoopProtocol::AreaJournalTransferCommand command, uint32_t transferId);
     bool SendPacketTo(const void* packet, int packetSize, uint32_t address, uint16_t port, const char* failurePrefix);
+    bool SendChatDatagram(const void* packet, int packetSize, const char* failurePrefix);
+    void InitializeChat();
+    void ShutdownChat();
+    bool HandleChatWindowMessage(unsigned message, uint64_t wParam, int64_t lParam);
+    void TickChat(float frameTime, float nowSeconds);
+    bool IsChatInputOpen() const;
+    std::string BuildChatTelemetry() const;
+    bool SendChatTextCommand(const std::string& text);
+    void ResetChat();
+    void RemoveChatSender(uint64_t accountToken);
+    bool CanAcceptChatTextPacket(const CoopProtocol::TextChatPacket& packet) const;
+    bool HandleChatTextPacket(const CoopProtocol::TextChatPacket& packet, const std::string& username, float nowSeconds);
+    bool HandleChatDatagram(
+        const CoopProtocol::PacketHeader& header,
+        const void* packetData,
+        int packetBytes,
+        uint32_t fromAddress,
+        uint16_t fromPort);
+    bool AcceptChatTextRate(uint64_t accountToken, float nowSeconds);
     bool SendPosePacketTo(const CoopProtocol::PlayerPosePacket& packet, uint32_t address, uint16_t port, const char* failurePrefix);
     bool SendSessionHelloTo(uint32_t address, uint16_t port, const char* failurePrefix);
     bool SendAreaLeaseTo(const CoopProtocol::AreaLeasePacket& packet, uint32_t address, uint16_t port, const char* failurePrefix);
@@ -1867,6 +1887,7 @@ private:
     void RelayReliablePayloadToPeers(const CoopProtocol::ReliableEnvelopePacket& packet, uint32_t fromAddress, uint16_t fromPort);
     void RelayPoseToPeers(const CoopProtocol::PlayerPosePacket& packet, uint32_t fromAddress, uint16_t fromPort);
     void RelayDatagramToPeers(const void* packet, int packetSize, uint32_t fromAddress, uint16_t fromPort, const char* failurePrefix);
+    void RelayChatTextToPeers(const void* packet, int packetSize, uint32_t fromAddress, uint16_t fromPort, const char* failurePrefix);
     bool RouteRemoteAreaEnemyStateDatagram(
         const void* packet,
         int packetSize,
@@ -4252,7 +4273,14 @@ private:
     std::unordered_map<uint64_t, float> m_hugePhysicsBoundsRepairFailureCooldownUntil;
     std::deque<PendingReliablePacket> m_reliableSendQueue;
     std::unordered_map<uint64_t, ReliableEndpointState> m_reliableEndpointStates;
+    struct ChatTextRateState
+    {
+        float windowStart = -1.0f;
+        float lastMessage = -1000.0f;
+        uint32_t count = 0;
+    };
     std::unordered_map<uint64_t, RemotePeerSession> m_remotePeers;
+    std::unordered_map<uint64_t, ChatTextRateState> m_chatTextRates;
     std::unordered_map<uint64_t, HostPlayerStateUploadReceive> m_hostPlayerStateUploadReceives;
     std::unordered_set<uint64_t> m_pendingHostPlayerStateUploadRequests;
     std::unordered_set<uint64_t> m_kickedAccountTokens;
@@ -4262,6 +4290,7 @@ private:
     uint64_t m_activePacketSourceAccountToken = 0;
     int m_maxSessionPlayers = 4;
     CoopNetworkTelemetry m_networkTelemetry;
+    CoopChat* m_chat = nullptr;
     CoopCoverageDiscovery m_coverageDiscovery;
     std::atomic<uint64_t> m_runtimeLogEmissions{0};
     uint64_t m_runtimeTransformHookCalls = 0;

--- a/CoopPrototype/Src/ModMainChat.cpp
+++ b/CoopPrototype/Src/ModMainChat.cpp
@@ -1,0 +1,208 @@
+#include "ModMain.h"
+#include "CoopChat.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+namespace
+{
+float ChatNowSeconds()
+{
+    return gEnv && gEnv->pTimer ? gEnv->pTimer->GetAsyncCurTime() : 0.0f;
+}
+}
+
+void ModMain::InitializeChat()
+{
+    if (!m_chat)
+        m_chat = new CoopChat();
+
+    m_chat->SetDatagramSender(
+        [this](const void* data, size_t size, const char* failurePrefix)
+        {
+            return SendChatDatagram(data, static_cast<int>(size), failurePrefix);
+        });
+    m_chat->SetIdentity(GetLocalAccountToken(), GetLocalUsername());
+    m_nullUi.ClearChatText();
+}
+
+void ModMain::ShutdownChat()
+{
+    delete m_chat;
+    m_chat = nullptr;
+    m_nullUi.ClearChatText();
+}
+
+bool ModMain::HandleChatWindowMessage(unsigned message, uint64_t wParam, int64_t lParam)
+{
+    return m_chat && m_chat->HandleNativeWindowMessage(message, wParam, lParam);
+}
+
+void ModMain::TickChat(float frameTime, float nowSeconds)
+{
+    if (!m_chat)
+        return;
+
+    m_chat->SetIdentity(GetLocalAccountToken(), GetLocalUsername());
+    const bool connected =
+        m_networkMode != CoopNetworkMode::Off &&
+        m_socket != kInvalidNetworkSocket &&
+        (m_networkMode == CoopNetworkMode::Host || m_hasRemoteSession);
+    m_chat->SetConnected(connected);
+    m_chat->Tick(frameTime, nowSeconds);
+    m_nullUi.SetChatText(m_chat->BuildHudState(nowSeconds).text);
+}
+
+bool ModMain::IsChatInputOpen() const
+{
+    return m_chat && m_chat->IsInputOpen();
+}
+
+std::string ModMain::BuildChatTelemetry() const
+{
+    return m_chat ? m_chat->BuildTelemetry() : "uninitialized";
+}
+
+bool ModMain::SendChatTextCommand(const std::string& text)
+{
+    return m_chat && m_chat->SendText(text);
+}
+
+void ModMain::ResetChat()
+{
+    if (m_chat)
+        m_chat->Reset();
+    m_nullUi.ClearChatText();
+}
+
+void ModMain::RemoveChatSender(uint64_t accountToken)
+{
+    if (m_chat)
+        m_chat->RemoveSender(accountToken);
+}
+
+bool ModMain::CanAcceptChatTextPacket(const CoopProtocol::TextChatPacket& packet) const
+{
+    return m_chat && m_chat->CanAcceptTextPacket(packet);
+}
+
+bool ModMain::HandleChatTextPacket(
+    const CoopProtocol::TextChatPacket& packet,
+    const std::string& username,
+    float nowSeconds)
+{
+    return m_chat && m_chat->HandleTextPacket(packet, username, nowSeconds);
+}
+
+bool ModMain::AcceptChatTextRate(uint64_t accountToken, float nowSeconds)
+{
+    if (accountToken == 0 || !std::isfinite(nowSeconds))
+        return false;
+
+    ChatTextRateState& state = m_chatTextRates[accountToken];
+    if (state.windowStart < 0.0f || nowSeconds - state.windowStart >= 3.0f)
+    {
+        state.windowStart = nowSeconds;
+        state.lastMessage = -1000.0f;
+        state.count = 0;
+    }
+    if (nowSeconds - state.lastMessage < 0.20f || state.count >= 8)
+        return false;
+    state.lastMessage = nowSeconds;
+    ++state.count;
+    return true;
+}
+
+bool ModMain::SendChatDatagram(const void* packet, int packetSize, const char* failurePrefix)
+{
+    if (!packet || packetSize <= 0 || m_socket == kInvalidNetworkSocket ||
+        m_networkMode == CoopNetworkMode::Off)
+        return false;
+
+    if (m_networkMode == CoopNetworkMode::Client)
+    {
+        uint32_t address = 0;
+        uint16_t port = 0;
+        if (!ResolveSessionHostEndpoint(address, port))
+            return false;
+        return SendPacketTo(packet, packetSize, address, port, failurePrefix);
+    }
+
+    bool sent = false;
+    bool allSent = true;
+    for (const auto& entry : m_remotePeers)
+    {
+        const RemotePeerSession& peer = entry.second;
+        if (peer.accountToken == 0 || peer.address == 0 || peer.port == 0)
+            continue;
+        sent = true;
+        allSent = SendPacketTo(packet, packetSize, peer.address, peer.port, failurePrefix) && allSent;
+    }
+    // A host can still use chat locally before another player has joined.
+    return m_networkMode == CoopNetworkMode::Host ? (!sent || allSent) : (sent && allSent);
+}
+
+void ModMain::RelayChatTextToPeers(
+    const void* packet,
+    int packetSize,
+    uint32_t fromAddress,
+    uint16_t fromPort,
+    const char* failurePrefix)
+{
+    if (m_networkMode != CoopNetworkMode::Host || !packet || packetSize <= 0)
+        return;
+
+    // Text chat is session-global, unlike area-scoped gameplay datagrams.
+    // Relay it to connected peers even while they are in another area or
+    // still finishing a world transition.
+    for (const auto& entry : m_remotePeers)
+    {
+        const RemotePeerSession& peer = entry.second;
+        if (peer.accountToken == 0 || peer.address == 0 || peer.port == 0 ||
+            (peer.address == fromAddress && peer.port == fromPort))
+            continue;
+        SendPacketTo(packet, packetSize, peer.address, peer.port, failurePrefix);
+    }
+}
+
+bool ModMain::HandleChatDatagram(
+    const CoopProtocol::PacketHeader& header,
+    const void* packetData,
+    int packetBytes,
+    uint32_t fromAddress,
+    uint16_t fromPort)
+{
+    if (header.type != static_cast<uint16_t>(CoopProtocol::PacketType::TextChat))
+        return false;
+    if (!packetData || packetBytes != static_cast<int>(sizeof(CoopProtocol::TextChatPacket)))
+        return true;
+
+    CoopProtocol::TextChatPacket packet = {};
+    std::memcpy(&packet, packetData, sizeof(packet));
+    const float now = ChatNowSeconds();
+    const RemotePeerSession* sourcePeer = FindRemotePeerByEndpoint(fromAddress, fromPort);
+    if (m_networkMode == CoopNetworkMode::Host)
+    {
+        if (!sourcePeer || packet.sourceAccountToken == 0 ||
+            sourcePeer->accountToken != packet.sourceAccountToken ||
+            !CanAcceptChatTextPacket(packet) ||
+            !AcceptChatTextRate(packet.sourceAccountToken, now) ||
+            !HandleChatTextPacket(packet, sourcePeer->username, now))
+            return true;
+        RelayChatTextToPeers(&packet, sizeof(packet), fromAddress, fromPort, "chat relay failed");
+        return true;
+    }
+
+    if (m_networkMode != CoopNetworkMode::Client || !sourcePeer ||
+        sourcePeer->accountToken != m_primaryRemotePeerToken ||
+        packet.sourceAccountToken == 0 ||
+        packet.sourceAccountToken == GetLocalAccountToken())
+        return true;
+
+    const auto peerIt = m_remotePeers.find(packet.sourceAccountToken);
+    if (peerIt == m_remotePeers.end() || !CanAcceptChatTextPacket(packet))
+        return true;
+    HandleChatTextPacket(packet, peerIt->second.username, now);
+    return true;
+}

--- a/CoopPrototype/Src/NullUi.cpp
+++ b/CoopPrototype/Src/NullUi.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <utility>
 
 #include <imgui.h>
 #include <Prey/CryRenderer/IRenderAuxGeom.h>
@@ -21,6 +22,9 @@ constexpr float kSystemFontSize = 1.05f;
 constexpr float kPriorityFontSize = 1.65f;
 constexpr float kImGuiSystemFontSize = 18.0f;
 constexpr float kImGuiPriorityFontSize = 28.0f;
+constexpr float kChatFontSize = 18.0f;
+constexpr float kChatRightMargin = 28.0f;
+constexpr float kChatBottomMargin = 24.0f;
 
 size_t SlotIndex(NullUiNoticeSlot slot)
 {
@@ -59,6 +63,16 @@ void NullUi::ClearNotice(NullUiNoticeSlot slot)
     notice->active = false;
 }
 
+void NullUi::SetChatText(std::string text)
+{
+    m_chatText = std::move(text);
+}
+
+void NullUi::ClearChatText()
+{
+    m_chatText.clear();
+}
+
 void NullUi::ClearAll()
 {
     for (Notice& notice : m_notices)
@@ -67,10 +81,14 @@ void NullUi::ClearAll()
         notice.durationSeconds = 0.0f;
         notice.active = false;
     }
+    ClearChatText();
 }
 
 bool NullUi::HasVisibleNotice(float nowSeconds) const
 {
+    if (!m_chatText.empty())
+        return true;
+
     for (const Notice& notice : m_notices)
     {
         if (IsNoticeVisible(notice, nowSeconds))
@@ -235,6 +253,42 @@ void NullUi::DrawImGuiOverlay(float nowSeconds)
             shadowColor(alpha),
             notice->text);
         y += kImGuiPriorityFontSize + 8.0f;
+    }
+
+    if (!m_chatText.empty())
+    {
+        const float scale = kChatFontSize / std::max(1.0f, ImGui::GetFontSize());
+        const float left = viewportPos.x + kChatRightMargin;
+        const float right = viewportPos.x + displaySize.x - kChatRightMargin;
+        const float maxWidth = std::max(1.0f, right - left);
+        const float wrapWidth = maxWidth / scale;
+        const ImVec2 measured = ImGui::CalcTextSize(m_chatText.c_str(), nullptr, false, wrapWidth);
+        const float textWidth = std::min(maxWidth, measured.x * scale);
+        const float textHeight = measured.y * scale;
+        const ImVec2 pos(
+            right - textWidth,
+            viewportPos.y + displaySize.y - kChatBottomMargin - textHeight);
+        drawList->PushClipRect(
+            ImVec2(left, viewportPos.y),
+            ImVec2(right, viewportPos.y + displaySize.y),
+            true);
+        drawList->AddText(
+            nullptr,
+            kChatFontSize,
+            ImVec2(pos.x + 2.0f, pos.y + 2.0f),
+            IM_COL32(0, 0, 0, 190),
+            m_chatText.c_str(),
+            nullptr,
+            wrapWidth);
+        drawList->AddText(
+            nullptr,
+            kChatFontSize,
+            pos,
+            IM_COL32(230, 242, 255, 255),
+            m_chatText.c_str(),
+            nullptr,
+            wrapWidth);
+        drawList->PopClipRect();
     }
 }
 

--- a/CoopPrototype/Src/NullUi.h
+++ b/CoopPrototype/Src/NullUi.h
@@ -25,6 +25,8 @@ class NullUi
 public:
     void ShowNotice(NullUiNoticeSlot slot, NullUiLayer layer, const std::string& text, float nowSeconds, float durationSeconds);
     void ClearNotice(NullUiNoticeSlot slot);
+    void SetChatText(std::string text);
+    void ClearChatText();
     void ClearAll();
     bool HasVisibleNotice(float nowSeconds) const;
     void DrawPreyHud(float nowSeconds);
@@ -48,4 +50,5 @@ private:
     float GetNoticeAlpha(const Notice& notice, float nowSeconds) const;
 
     std::array<Notice, kNoticeCount> m_notices;
+    std::string m_chatText;
 };


### PR DESCRIPTION
## Summary
- add lightweight session-wide text chat for 2-16 players
- open chat with Y, backslash/hash, or plus and render it through the existing NullUI HUD
- authenticate senders, rate-limit messages, reject malformed text, and suppress duplicate UDP packets
- keep voice capture, codecs, and audio traffic out of this change

## Validation
- full Windows DLL cross-build
- ABI smoke executable under Wine
- focused chat smoke coverage for send/receive, duplicate suppression, malformed/control text, Unicode bounds, EU/US open keys, input cancellation, native close pass-through, and disconnect cleanup
- independent final review: no blocking findings