### PR TITLE
Create the advertised runtime diagnostics log

### DIFF
--- a/CoopPrototype/README.md
+++ b/CoopPrototype/README.md
@@ -51,7 +51,7 @@ High-rate traffic is limited to compact player/enemy pose and actively moving pr
 - **Player state corrupt for exact save:** restore that account/save state from backup, or remove only the reported exact-save state to create an empty player slot. The Host never substitutes another save's inventory or progression.
 - **GPU/VRAM startup failure during local multi-instance testing:** terminate stale Prey/Proton/Wine processes before retrying. Do not repeatedly relaunch into exhausted VRAM.
 - **Missing Host geometry during local multi-instance testing:** stop all test instances and rebuild that profile's shader cache. Each test prefix must use its own cache directory; sharing Steam's live `shadercache/480490` between simultaneous renderers can corrupt or starve the Host cache.
-- **Diagnostics:** the large developer window and verbose traces are off by default. Enable them only for a bounded reproducer; normal play should not emit sustained console spam.
+- **Diagnostics:** the bounded runtime report is written automatically to `Saved Games/Arkane Studios/Prey/coop_runtime_log.txt`, next to `Game.log`. The large developer window and verbose traces are off by default; enable them only for a bounded reproducer so normal play does not emit sustained console spam.
 
 ## Build
 

--- a/CoopPrototype/Src/CoopRuntimeLog.cpp
+++ b/CoopPrototype/Src/CoopRuntimeLog.cpp
@@ -9,9 +9,15 @@
 #include <chrono>
 #include <cstddef>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
 #include <mutex>
+#include <sstream>
 #include <string>
 #include <unordered_map>
+
+#include <windows.h>
 
 #include <Chairloader/IChairLogger.h>
 
@@ -29,6 +35,42 @@ std::unordered_map<std::string, RateLimitState> g_rateLimits;
 std::unordered_map<std::string, RateLimitState> g_repeatLimits;
 std::atomic<uint64_t> g_suppressedCount = 0;
 
+// Keep the on-disk report deliberately small and cheap: WriteRaw already
+// records every emitted line in the lock-free ring below. The file is a
+// snapshot of that ring, refreshed at most once per second from the normal
+// update thread, rather than a disk write on every hook/log call.
+constexpr std::size_t kRuntimeFileMaxLines = 512;
+constexpr std::chrono::seconds kRuntimeFileFlushInterval{1};
+std::string BuildRuntimeFileHeader()
+{
+    SYSTEMTIME localTime = {};
+    GetLocalTime(&localTime);
+
+    std::ostringstream out;
+    out << "CoopPrototype runtime log\n"
+        << "format=1\n"
+        << "bounded_recent_lines=512\n"
+        << "lines_are_rate_limited_runtime_events\n"
+        << "pid=" << GetCurrentProcessId() << "\n"
+        << "started_local="
+        << std::setfill('0') << std::setw(4) << localTime.wYear << "-"
+        << std::setw(2) << localTime.wMonth << "-"
+        << std::setw(2) << localTime.wDay << "T"
+        << std::setw(2) << localTime.wHour << ":"
+        << std::setw(2) << localTime.wMinute << ":"
+        << std::setw(2) << localTime.wSecond << "."
+        << std::setw(3) << localTime.wMilliseconds << "\n"
+        << "---\n";
+    return out.str();
+}
+
+std::mutex g_runtimeFileMutex;
+std::filesystem::path g_runtimeFilePath;
+std::string g_runtimeFileHeader;
+std::chrono::steady_clock::time_point g_runtimeFileLastFlush{};
+std::atomic<uint64_t> g_runtimeFileLastSequence{0};
+std::atomic<bool> g_runtimeFileConfigured{false};
+
 // Lock-free recent-line ring for crash traces (see RecentLines in the
 // header). No mutexes: the crash handler may run on a faulting thread where
 // a locked mutex could deadlock. Fixed slots, atomic sequence index, length
@@ -41,10 +83,74 @@ struct LogRingSlot
 {
     char text[kRingLineCapacity] = {};
     std::atomic<std::uint16_t> length{0};
+    // Stores sequence + 1 after text and length are fully published. A
+    // separate sequence lets readers distinguish an old wrapped slot from a
+    // line that is still reserved but not written.
+    std::atomic<uint64_t> publishedSequence{0};
 };
 
 std::atomic<uint64_t> g_ringSequence{0};
+std::atomic<uint64_t> g_ringPublishedThrough{0};
 std::array<LogRingSlot, kRingSlots> g_ringSlots{};
+
+void AdvancePublishedRing(uint64_t sequence)
+{
+    const uint64_t candidate = sequence + 1;
+    uint64_t published = g_ringPublishedThrough.load(std::memory_order_acquire);
+    if (candidate <= published)
+        return;
+
+    const uint64_t reserved = g_ringSequence.load(std::memory_order_acquire);
+    const uint64_t target = candidate > reserved ? candidate : reserved;
+
+    // Writers reserve slots independently. Only advance the public cursor
+    // across a contiguous run, so a paused writer cannot make Flush() believe
+    // that its reserved line is already on disk. The scan is bounded to one
+    // ring length; a later publication can finish the rest without making a
+    // log call spend unbounded time here.
+    for (;;)
+    {
+        uint64_t scan = published;
+        while (scan < target && scan - published <= kRingSlots)
+        {
+            const LogRingSlot& slot = g_ringSlots[scan % kRingSlots];
+            const uint64_t slotSequence =
+                slot.publishedSequence.load(std::memory_order_acquire);
+            if (slotSequence == scan + 1)
+            {
+                ++scan;
+                continue;
+            }
+
+            // If this slot already contains a newer sequence, the old
+            // reservation has fallen out of the bounded ring and can no
+            // longer be written without destroying a newer line. Treat it as
+            // dropped and keep the published cursor moving.
+            if (slotSequence > scan + 1)
+            {
+                ++scan;
+                continue;
+            }
+            else
+            {
+                break;
+            }
+        }
+        if (scan == published)
+            return;
+
+        if (g_ringPublishedThrough.compare_exchange_weak(
+                published,
+                scan,
+                std::memory_order_acq_rel,
+                std::memory_order_acquire))
+        {
+            return;
+        }
+        if (candidate <= published)
+            return;
+    }
+}
 
 void RecordRingLine(std::string_view message)
 {
@@ -56,6 +162,54 @@ void RecordRingLine(std::string_view message)
         std::memcpy(slot.text, message.data(), copyLength);
     slot.text[copyLength] = '\0';
     slot.length.store(static_cast<std::uint16_t>(copyLength), std::memory_order_release);
+    slot.publishedSequence.store(sequence + 1, std::memory_order_release);
+    AdvancePublishedRing(sequence);
+}
+
+bool WriteRuntimeFileSnapshotLocked(uint64_t sequence)
+{
+    if (!g_runtimeFileConfigured || g_runtimeFilePath.empty())
+        return false;
+
+    std::filesystem::path temporaryPath = g_runtimeFilePath;
+    temporaryPath += L".tmp.";
+    temporaryPath += std::to_wstring(GetCurrentProcessId());
+
+    std::ofstream output(
+        temporaryPath,
+        std::ios::binary | std::ios::out | std::ios::trunc);
+    if (!output)
+        return false;
+
+    output.write(g_runtimeFileHeader.data(), static_cast<std::streamsize>(g_runtimeFileHeader.size()));
+    const std::string recent = CoopRuntimeLog::RecentLines(kRuntimeFileMaxLines);
+    if (!recent.empty())
+        output.write(recent.data(), static_cast<std::streamsize>(recent.size()));
+    output.flush();
+    if (!output)
+    {
+        output.close();
+        std::error_code ignored;
+        std::filesystem::remove(temporaryPath, ignored);
+        return false;
+    }
+    output.close();
+
+    // Replace the previous complete snapshot only after the temporary file is
+    // fully written. This keeps a crash or interrupted write from exposing a
+    // truncated runtime report to the next bug-report collection.
+    if (!MoveFileExW(
+            temporaryPath.c_str(),
+            g_runtimeFilePath.c_str(),
+            MOVEFILE_REPLACE_EXISTING))
+    {
+        std::error_code ignored;
+        std::filesystem::remove(temporaryPath, ignored);
+        return false;
+    }
+
+    g_runtimeFileLastSequence.store(sequence, std::memory_order_release);
+    return true;
 }
 
 constexpr std::size_t kMaxRepeatKeys = 512;
@@ -71,6 +225,75 @@ void WriteRaw(std::string_view message)
     if (CoopRuntimeConfig::Flag("COOP_OVERLAY_LOG"))
         OverlayLog("[CoopPrototype] {}", message);
 }
+}
+
+bool CoopRuntimeLog::ConfigureFile(const std::filesystem::path& path)
+{
+    if (path.empty())
+        return false;
+
+    std::lock_guard<std::mutex> lock(g_runtimeFileMutex);
+    if (g_runtimeFileConfigured.load(std::memory_order_acquire) && g_runtimeFilePath == path)
+        return true;
+
+    std::error_code error;
+    const std::filesystem::path parent = path.parent_path();
+    if (!parent.empty())
+        std::filesystem::create_directories(parent, error);
+    if (error)
+        return false;
+
+    g_runtimeFilePath = path;
+    g_runtimeFileHeader = BuildRuntimeFileHeader();
+    g_runtimeFileConfigured.store(true, std::memory_order_release);
+    g_runtimeFileLastFlush = std::chrono::steady_clock::now() - kRuntimeFileFlushInterval;
+    g_runtimeFileLastSequence.store(0, std::memory_order_release);
+    if (!WriteRuntimeFileSnapshotLocked(g_ringPublishedThrough.load(std::memory_order_acquire)))
+    {
+        g_runtimeFileConfigured.store(false, std::memory_order_release);
+        g_runtimeFilePath.clear();
+        g_runtimeFileHeader.clear();
+        return false;
+    }
+    return true;
+}
+
+void CoopRuntimeLog::Flush()
+{
+    const uint64_t sequence = g_ringPublishedThrough.load(std::memory_order_acquire);
+    if (!g_runtimeFileConfigured.load(std::memory_order_acquire) ||
+        sequence == g_runtimeFileLastSequence.load(std::memory_order_acquire))
+    {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(g_runtimeFileMutex);
+    if (!g_runtimeFileConfigured.load(std::memory_order_acquire))
+        return;
+
+    const auto now = std::chrono::steady_clock::now();
+    if (now - g_runtimeFileLastFlush < kRuntimeFileFlushInterval)
+        return;
+
+    g_runtimeFileLastFlush = now;
+    const uint64_t lockedSequence = g_ringPublishedThrough.load(std::memory_order_acquire);
+    if (lockedSequence == g_runtimeFileLastSequence.load(std::memory_order_acquire))
+        return;
+    WriteRuntimeFileSnapshotLocked(lockedSequence);
+}
+
+void CoopRuntimeLog::CloseFile()
+{
+    std::lock_guard<std::mutex> lock(g_runtimeFileMutex);
+    if (!g_runtimeFileConfigured.load(std::memory_order_acquire))
+        return;
+
+    WriteRuntimeFileSnapshotLocked(g_ringPublishedThrough.load(std::memory_order_acquire));
+    g_runtimeFileConfigured.store(false, std::memory_order_release);
+    g_runtimeFilePath.clear();
+    g_runtimeFileHeader.clear();
+    g_runtimeFileLastSequence.store(0, std::memory_order_release);
+    g_runtimeFileLastFlush = {};
 }
 
 void CoopRuntimeLog::Write(std::string_view message)
@@ -177,7 +400,7 @@ std::string CoopRuntimeLog::RecentLines(std::size_t maxLines)
     if (maxLines == 0)
         return {};
 
-    const uint64_t next = g_ringSequence.load(std::memory_order_relaxed);
+    const uint64_t next = g_ringPublishedThrough.load(std::memory_order_acquire);
     const uint64_t available = next < kRingSlots ? next : static_cast<uint64_t>(kRingSlots);
     const uint64_t take = std::min<uint64_t>(maxLines, available);
     std::string out;
@@ -186,11 +409,18 @@ std::string CoopRuntimeLog::RecentLines(std::size_t maxLines)
     // Oldest to newest so the returned order is newest-last.
     for (uint64_t i = take; i > 0; --i)
     {
-        const LogRingSlot& slot = g_ringSlots[(next - i) % kRingSlots];
+        const uint64_t sequence = next - i;
+        const LogRingSlot& slot = g_ringSlots[sequence % kRingSlots];
+        if (slot.publishedSequence.load(std::memory_order_acquire) != sequence + 1)
+            continue;
         const std::uint16_t length = slot.length.load(std::memory_order_acquire);
         if (length == 0)
             continue;
-        out.append(slot.text, length);
+        std::array<char, kRingLineCapacity> line = {};
+        std::memcpy(line.data(), slot.text, length);
+        if (slot.publishedSequence.load(std::memory_order_acquire) != sequence + 1)
+            continue;
+        out.append(line.data(), length);
         out.push_back('\n');
     }
     return out;

--- a/CoopPrototype/Src/CoopRuntimeLog.h
+++ b/CoopPrototype/Src/CoopRuntimeLog.h
@@ -2,11 +2,18 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
 #include <string>
 #include <string_view>
 
 namespace CoopRuntimeLog
 {
+// Configure the bounded user-facing snapshot written for bug reports. The
+// path is kept as std::filesystem::path so non-ASCII Windows profiles are not
+// routed through the active code page.
+bool ConfigureFile(const std::filesystem::path& path);
+void Flush();
+void CloseFile();
 void Write(std::string_view message);
 bool WriteRateLimited(
     std::string_view key,

--- a/CoopPrototype/Src/ModMain.cpp
+++ b/CoopPrototype/Src/ModMain.cpp
@@ -30934,6 +30934,31 @@ void ModMain::InstallCrashExceptionHandler()
             g_crashTraceDirectory = CoopFilesystem::ToUtf8(crashDir);
     }
 
+    const std::filesystem::path runtimeLogPath = profileRoot.empty()
+        ? std::filesystem::path("coop_runtime_log.txt")
+        : profileRoot / "coop_runtime_log.txt";
+    std::filesystem::path configuredRuntimeLogPath = runtimeLogPath;
+    bool runtimeLogConfigured = CoopRuntimeLog::ConfigureFile(runtimeLogPath);
+    if (!runtimeLogConfigured && !profileRoot.empty())
+    {
+        configuredRuntimeLogPath = std::filesystem::path("coop_runtime_log.txt");
+        runtimeLogConfigured = CoopRuntimeLog::ConfigureFile(configuredRuntimeLogPath);
+    }
+    if (runtimeLogConfigured)
+    {
+        LogCoop(
+            "runtime log initialized path=" +
+            CoopFilesystem::ToUtf8(configuredRuntimeLogPath));
+        // Persist the startup breadcrumb immediately. The normal update loop
+        // refreshes this bounded snapshot at most once per second, but a
+        // loader-time crash must still leave proof that the file was active.
+        CoopRuntimeLog::Flush();
+    }
+    else
+    {
+        LogCoop("runtime log initialization failed");
+    }
+
     if (!g_purecallTraceHandlerInstalled)
     {
         g_previousPurecallHandler = _set_purecall_handler(&CoopPurecallTraceHandler);
@@ -30978,11 +31003,12 @@ void ModMain::RemoveCrashExceptionHandler()
         g_invalidParameterTraceHandlerInstalled = false;
     }
 
-    if (!g_crashVectoredHandler)
-        return;
-
-    RemoveVectoredExceptionHandler(g_crashVectoredHandler);
-    g_crashVectoredHandler = nullptr;
+    if (g_crashVectoredHandler)
+    {
+        RemoveVectoredExceptionHandler(g_crashVectoredHandler);
+        g_crashVectoredHandler = nullptr;
+    }
+    CoopRuntimeLog::CloseFile();
 }
 
 //---------------------------------------------------------------------------------
@@ -35119,6 +35145,11 @@ void ModMain::OnArkSaveLoadSerializePersistentStateHook(
 void ModMain::MainUpdate(unsigned updateFlags)
 {
     const float frameTime = gEnv && gEnv->pTimer ? gEnv->pTimer->GetFrameTime() : 0.0f;
+
+    // Refresh the bounded report outside the log hot path. This keeps the
+    // release diagnostic available without turning every emitted event into a
+    // synchronous disk write.
+    CoopRuntimeLog::Flush();
 
     // Periodic self-profiling dump (issue #2): hook cost breakdown + guarded
     // call / VirtualQuery totals straight into Game.log, independent of the


### PR DESCRIPTION
## Summary
- create `coop_runtime_log.txt` beside `Game.log` on startup
- keep a bounded snapshot of the 512 latest rate-limited runtime events
- replace snapshots atomically and only when new events exist

## Verification
- Xwin/MSVC Release build
- independent code review and correction pass
- exact DLL deployed on Linux and native Windows
- log created and updated on both systems
- Linux host and native Windows client reached `connected_same_level`

This addresses the missing diagnostic file reported in #20; it does not claim to fix the separate texture, Looking Glass, or crash symptoms.