### PR TITLE
Fix client save quarantine directory naming

### DIFF
--- a/CoopPrototype/Src/ModMain.cpp
+++ b/CoopPrototype/Src/ModMain.cpp
@@ -5460,7 +5460,7 @@ std::string BuildCoopClientTempSavePath(const std::string& saveKey, const std::s
     std::snprintf(
         fileName,
         sizeof(fileName),
-        "PreyCoopClientSave_%s_%s_%s_r%d_%s.sav",
+        "PreyCoopClientSave_%s_%s_%s_r%d_%s",
         key.c_str(),
         Hex32(originalPathHash).c_str(),
         slot.c_str(),


### PR DESCRIPTION
## Summary
- remove the `.sav` suffix from redirected client save quarantine directory names
- restore the native extensionless save-slot shape so `<slot>/save.CSF` remains creatable by the asynchronous compressor

## Evidence
The redirected name was passed to the native save API as a save-slot directory, but ended in `.sav`. In the reproduced failure, native deletion was followed by failure to create `<slot>/save.CSF`, leaving texture streaming paused as reported in #20 . Removing the file suffix restored the native extensionless slot shape: repeated redirected saves created `save.CSF` successfully, `streamPauseMask` remained `0`, and the target texture retained its full mip.

## Validation
- fresh `origin/main` checkout
- pinned Chairloader Common revision `97899fbd86ab183a08ed579d6f95ed40262c7e15`
- MSVC container build completed successfully (`122/123`, final link, exit 0)
- two repeated redirected-save cycles passed on the native-Windows client
- no `CCompressorThread::CFile ERROR`; target remained `minLoadedMip=0`, `mipZeroResident=1`
- `git diff --check` passed
- no deployment from the clean PR worktree