### PR TITLE
Fix client pickup of shared weapons

### DIFF
--- a/CoopPrototype/Src/CoopNativeInventoryBridge.cpp
+++ b/CoopPrototype/Src/CoopNativeInventoryBridge.cpp
@@ -539,6 +539,57 @@ bool ModMain::EnsureLocalPlayerWeaponRegistered(unsigned itemId, const char* rea
     return true;
 }
 
+bool ModMain::ResetLocalPlayerWeaponsForInventoryReplacement(const char* reason)
+{
+    ArkPlayer* player = ArkPlayer::GetInstancePtr();
+    if (!player || !IsLikelyRuntimeCppObject(player, sizeof(ArkPlayer)) || !player->GetEntity())
+        return false;
+
+    std::string guardReason;
+    ArkPlayerWeaponComponent& weaponComponent = player->m_weaponComponent;
+    if (!TryGuardedVoidCall(
+            "coop weapon replacement RemoveWeapons",
+            [&weaponComponent]()
+            {
+                // This must run while the outgoing inventory still owns its
+                // weapon entities. Vanilla can then detach/hide the equipped
+                // weapon and clear its HUD state through the normal callbacks.
+                weaponComponent.RemoveWeapons();
+                weaponComponent.m_weaponTypesAcquired.clear();
+            },
+            &guardReason))
+    {
+        LogCoop(
+            "local weapon replacement reset failed" +
+            (reason && reason[0] ? ": " + std::string(reason) : std::string()) +
+            (guardReason.empty() ? std::string() : " guard=" + StatusToken(guardReason)));
+        return false;
+    }
+
+    ArkQuickSelectComponent& quickSelect = player->m_playerComponent.GetQuickSelectComponent();
+    if (!TryGuardedVoidCall(
+            "coop weapon replacement quickselect reset",
+            [&quickSelect]()
+            {
+                quickSelect.CloseQuickSelect();
+                quickSelect.Reset();
+                quickSelect.RefreshFilterFeedback();
+            },
+            &guardReason))
+    {
+        LogCoop(
+            "local weapon replacement quickselect reset failed" +
+            (reason && reason[0] ? ": " + std::string(reason) : std::string()) +
+            (guardReason.empty() ? std::string() : " guard=" + StatusToken(guardReason)));
+        return false;
+    }
+
+    LogCoop(
+        "local weapon state reset before inventory replacement" +
+        (reason && reason[0] ? ": " + std::string(reason) : std::string()));
+    return true;
+}
+
 uint32_t ModMain::ReconcileLocalPlayerWeaponsFromInventory(const char* reason, bool resetWeaponState)
 {
     ArkPlayer* player = ArkPlayer::GetInstancePtr();

--- a/CoopPrototype/Src/CoopPlayerSidecar.cpp
+++ b/CoopPrototype/Src/CoopPlayerSidecar.cpp
@@ -4391,6 +4391,16 @@ bool ModMain::TryRestorePendingPlayerSidecarInventory(const char* reason, bool n
             return false;
         }
 
+        // Tear down equipped weapons before deleting their inventory owners.
+        // Reversing this order leaves the Host-save reticle/attachment alive
+        // while the Client inventory is already empty, and later pickups can
+        // never finish the outgoing weapon's unequip transition.
+        if (!ResetLocalPlayerWeaponsForInventoryReplacement("sidecar inventory native clear"))
+        {
+            m_lastPlayerSidecarEvent = "inventory restore waiting: weapon reset failed";
+            return false;
+        }
+
         if (!TryGuardedVoidCall(
                 "coop inventory restore RemoveAllItems",
                 [&]()
@@ -4409,7 +4419,6 @@ bool ModMain::TryRestorePendingPlayerSidecarInventory(const char* reason, bool n
 
         m_pendingPlayerSidecarInventoryRestoreNeedsClear = false;
         m_playerSidecarInventoryApplied = 0;
-        ReconcileLocalPlayerWeaponsFromInventory("sidecar inventory native clear", true);
     }
 
     const EntityId playerEntityId = playerEntity->GetId();

--- a/CoopPrototype/Src/CoopSharedDropSync.cpp
+++ b/CoopPrototype/Src/CoopSharedDropSync.cpp
@@ -1,4 +1,5 @@
 #include "ModMain.h"
+#include "CoopItemClassification.h"
 #include "CoopSerialSequence.h"
 #include "CoopRuntimeGuards.h"
 
@@ -335,16 +336,22 @@ void ModMain::OnNativeSharedItemPicked(EntityId itemEntityId, EntityId pickerId,
     IEntity* grantedEntity = gEnv && gEnv->pEntitySystem
         ? gEnv->pEntitySystem->GetEntity(itemEntityId)
         : nullptr;
-    if (grantedEntity)
-    {
-        std::string presentationReason;
+    CArkItem* grantedItem = grantedEntity
+        ? CArkItem::GetItemFromEntityId(itemEntityId)
+        : nullptr;
+    std::string presentationReason;
+    const bool isWeapon = CoopItemClassification::IsRealWeaponInventoryItem(grantedItem, presentationReason);
+    if (grantedEntity && !isWeapon)
         SetSharedDropWorldPresentation(*grantedEntity, false, presentationReason);
-    }
 
     // Do not erase the entity binding here. CArkItem::PickUp may keep the world
     // entity alive during its native lerp, and that exact interval previously
     // allowed the same shared stack to be picked up repeatedly. OnRemove retires
     // the binding, or a later Drop replaces it with a fresh shared lifetime.
+    // The tombstone blocks another pickup; do not overwrite the presentation
+    // chosen by native PickUp. In particular, forcing an inventory-owned weapon
+    // invisible/non-physical prevents a later weapon-wheel selection from
+    // completing until the next level load rebuilds the weapon entity.
     if (!gEnv || !gEnv->pEntitySystem || !gEnv->pEntitySystem->GetEntity(itemEntityId))
     {
         m_sharedDropByEntityId.erase(byEntity);
@@ -500,9 +507,12 @@ bool ModMain::RemoveSharedDropLocal(SharedDropRecord& record, bool grantToLocalP
         IEntity* grantedEntity = gEnv && gEnv->pEntitySystem
             ? gEnv->pEntitySystem->GetEntity(entityId)
             : nullptr;
+        const bool isWeapon = CoopItemClassification::IsRealWeaponInventoryItem(item, reason);
         bool presentationHidden = !grantedEntity;
-        if (grantedEntity)
+        if (grantedEntity && !isWeapon)
             presentationHidden = SetSharedDropWorldPresentation(*grantedEntity, false, reason);
+        else if (grantedEntity)
+            presentationHidden = grantedEntity->IsHidden();
         else
         {
             m_sharedDropByEntityId.erase(entityId);

--- a/CoopPrototype/Src/ModMain.cpp
+++ b/CoopPrototype/Src/ModMain.cpp
@@ -8036,6 +8036,10 @@ static auto s_hookCArkItemTryGiveInventory = CArkItem::FTryGiveInventory.MakeHoo
 static auto s_hookCArkItemDrop = CArkItem::FDrop.MakeHook();
 static auto s_hookCArkItemClone = CArkItem::FClone.MakeHook();
 static auto s_hookCArkItemPickUp = CArkItem::FPickUp.MakeHook();
+static auto s_hookArkPlayerWeaponComponentEquipWeapon = ArkPlayerWeaponComponent::FEquipWeaponOv0.MakeHook();
+static auto s_hookCArkWeaponOnEquip = CArkWeapon::FOnEquip.MakeHook();
+static thread_local ArkPlayerWeaponComponent* s_activeLocalWeaponEquipComponent = nullptr;
+static thread_local unsigned s_activeLocalWeaponEquipId = INVALID_ENTITYID;
 static auto s_hookArkPlayerCarryThrowCarriedEntity = ArkPlayerCarry::FThrowCarriedEntity.MakeHook();
 static auto s_hookArkPlayerCarryStopCarrying = ArkPlayerCarry::FStopCarrying.MakeHook();
 static auto s_hookArkWeaponUtilsDoHitImpulse1 = ArkWeaponUtils::FDoHitImpulseOv1.MakeHook();
@@ -19440,6 +19444,40 @@ static bool CArkItem_PickUp_Hook(CArkItem* item, const unsigned pickerId, bool s
             gMod->CaptureLocalPlayerPickupRecovery(pickerId, "CArkItem::PickUp");
     }
     return result;
+}
+
+static bool ArkPlayerWeaponComponent_EquipWeapon_Hook(
+    ArkPlayerWeaponComponent* component,
+    unsigned weaponId)
+{
+    ArkPlayerWeaponComponent* previousComponent = s_activeLocalWeaponEquipComponent;
+    const unsigned previousWeaponId = s_activeLocalWeaponEquipId;
+    if (ArkPlayer::GetInstancePtr() && component == &ArkPlayer::GetInstance().m_weaponComponent)
+    {
+        s_activeLocalWeaponEquipComponent = component;
+        s_activeLocalWeaponEquipId = weaponId;
+    }
+    const bool result = s_hookArkPlayerWeaponComponentEquipWeapon.InvokeOrig(component, weaponId);
+    s_activeLocalWeaponEquipComponent = previousComponent;
+    s_activeLocalWeaponEquipId = previousWeaponId;
+    return result;
+}
+
+static void CArkWeapon_OnEquip_Hook(CArkWeapon* weapon)
+{
+    const unsigned weaponId = weapon ? weapon->GetEntityId() : INVALID_ENTITYID;
+    if (weapon && ArkPlayer::GetInstancePtr() &&
+        s_activeLocalWeaponEquipComponent == &ArkPlayer::GetInstance().m_weaponComponent &&
+        s_activeLocalWeaponEquipId == weaponId &&
+        weapon->m_ownerId == INVALID_ENTITYID)
+    {
+        // ArkPlayerWeaponComponent is synchronously equipping this exact item
+        // for the local player, but a network-materialized drop can reach this
+        // callback before PickUp publishes its owner. Restore that native
+        // invariant so Vanilla builds the attachment and weapon actions.
+        weapon->m_ownerId = ArkPlayer::GetInstance().GetEntityId();
+    }
+    s_hookCArkWeaponOnEquip.InvokeOrig(weapon);
 }
 
 static void CArkItem_ResetCount_Hook(CArkItem* item, int count)
@@ -31586,6 +31624,8 @@ void ModMain::InitHooks()
         s_hookCArkItemDrop.SetHookFunc(&CArkItem_Drop_Hook);
         s_hookCArkItemClone.SetHookFunc(&CArkItem_Clone_Hook);
         s_hookCArkItemPickUp.SetHookFunc(&CArkItem_PickUp_Hook);
+        s_hookArkPlayerWeaponComponentEquipWeapon.SetHookFunc(&ArkPlayerWeaponComponent_EquipWeapon_Hook);
+        s_hookCArkWeaponOnEquip.SetHookFunc(&CArkWeapon_OnEquip_Hook);
     }
     s_hookArkPlayerCarryThrowCarriedEntity.SetHookFunc(&ArkPlayerCarry_ThrowCarriedEntity_Hook);
     s_hookArkPlayerCarryStopCarrying.SetHookFunc(&ArkPlayerCarry_StopCarrying_Hook);

--- a/CoopPrototype/Src/ModMain.h
+++ b/CoopPrototype/Src/ModMain.h
@@ -713,6 +713,7 @@ public:
     void BeginPlayerSidecarInventoryFeedbackSuppression(const char* reason);
     void EndPlayerSidecarInventoryFeedbackSuppression(const char* reason);
     bool EnsureLocalPlayerWeaponRegistered(unsigned itemId, const char* reason);
+    bool ResetLocalPlayerWeaponsForInventoryReplacement(const char* reason);
     uint32_t ReconcileLocalPlayerWeaponsFromInventory(const char* reason, bool resetWeaponState);
     void OnArkPlayerCarryThrowHook(ArkPlayerCarry* carry, const char* phase, bool result);
     void OnArkPlayerCarryStopHook(EntityId entityId, float impulse, bool applyAngularImpulse, bool thrown, bool fromSerialize);


### PR DESCRIPTION
## Summary
- clear Vanilla weapon, reticle, and quick-select state before replacing the joining client's inventory
- preserve Vanilla's presentation for weapons accepted through shared-drop pickup while retaining the shared-drop tombstone against duplicate pickups
- restore the local owner invariant during the exact nested `EquipWeapon` / `OnEquip` call for a network-materialized weapon

## Evidence
The exact host-drop/client-pickup reproduction reached `ArkPlayerWeaponComponent::EquipWeapon`, but native `CArkWeapon::OnEquip` observed owner `0` and returned without creating the attachment or weapon actions. The component still recorded the weapon as equipped, leaving it visible in inventory/the weapon wheel but unusable until a reconnect or level change rebuilt it.

With this patch, that same nested local equip publishes the already-known local player owner before Vanilla `OnEquip` runs. Vanilla then creates the held attachment/actions normally; no weapon-specific actions are synthesized by the mod.

## Validation
- pinned-Chairloader Release cross-build completed successfully; `CoopAbiSmokeTest` and `CoopPrototype.dll` linked
- exact empty-client test: host dropped a pistol, client picked it up, host dropped a Wrench, client picked it up and switched to it
- native Wrench hit completed successfully after the switch
- each picked weapon remained a single client-owned inventory entity, with no visible ownerless shared-drop copy
- `git diff --check` passed
